### PR TITLE
HTTP requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,11 @@ lazy val commons = (project in file("commons"))
 	.settings(
 		commonsettings,
 		libraryDependencies ++= kiamaDependencies,
-		libraryDependencies ++= Seq("org.scalaj" %% "scalaj-http" % "2.4.2"))
+		libraryDependencies ++= Seq(
+			"org.scalaj" %% "scalaj-http" % "2.4.2",
+			"org.http4s" %% "http4s-blaze-server" % "0.21.16",
+			"org.http4s" %% "http4s-blaze-client" % "0.21.16",
+			"org.http4s" %% "http4s-dsl" % "0.21.16"))
 
 
 lazy val buildComponent = taskKey[Unit]("Generates the component jar for GraalVM installation.")

--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,8 @@ lazy val commons = (project in file("commons"))
 	.enablePlugins(BuildInfoPlugin)
 	.settings(
 		commonsettings,
-		libraryDependencies ++= kiamaDependencies)
+		libraryDependencies ++= kiamaDependencies,
+		libraryDependencies ++= Seq("org.scalaj" %% "scalaj-http" % "2.4.2"))
 
 
 lazy val buildComponent = taskKey[Unit]("Generates the component jar for GraalVM installation.")

--- a/build.sbt
+++ b/build.sbt
@@ -128,10 +128,13 @@ lazy val root = (project in file("."))
 		commonsettings,
 		mainClass in Compile := (mainClass in Compile in reference).value,
 		libraryDependencies ++= Seq(
+			"org.http4s" %% "http4s-blaze-server" % "0.21.16" % "test",
+			"org.http4s" %% "http4s-blaze-client" % "0.21.16" % "test",
+			"org.http4s" %% "http4s-dsl" % "0.21.16" % "test",
             "org.scalatest" %% "scalatest" % "3.2.3" % "test",
 			"org.scalatestplus" %% "scalacheck-1-15" % "3.2.3.0" % "test",
             "org.scalacheck" %% "scalacheck" % "1.15.2" % "test",
-			"wolfendale" %% "scalacheck-gen-regexp" % "0.1.2"
+			"wolfendale" %% "scalacheck-gen-regexp" % "0.1.2",
 		) ++ kiamaDependencies
 	)
 	.dependsOn(
@@ -181,11 +184,8 @@ lazy val commons = (project in file("commons"))
 	.settings(
 		commonsettings,
 		libraryDependencies ++= kiamaDependencies,
-		libraryDependencies ++= Seq(
-			"org.scalaj" %% "scalaj-http" % "2.4.2",
-			"org.http4s" %% "http4s-blaze-server" % "0.21.16",
-			"org.http4s" %% "http4s-blaze-client" % "0.21.16",
-			"org.http4s" %% "http4s-dsl" % "0.21.16"))
+		libraryDependencies += "org.scalaj" %% "scalaj-http" % "2.4.2"
+	)
 
 
 lazy val buildComponent = taskKey[Unit]("Generates the component jar for GraalVM installation.")

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Backend.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Backend.scala
@@ -43,6 +43,7 @@ trait Backend {
     type Primitive
     def argumentP(i : Int) : Primitive
     def capabilityP(cap : String) : Primitive
+    def httpClientP(method : String, url : String) : Primitive
     def readerReadP(filename : String) : Primitive
     def recConcatP() : Primitive
     def recSelectP() : Primitive

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
@@ -38,6 +38,15 @@ trait Compiler {
         compileHalt(prog.expression)
     }
 
+    lazy val capabilityNames =
+        Set("HttpGet", "HttpDelete", "HttpPut", "HttpPost", "Reader", "Writer")
+
+    /**
+     * Name of capability type?
+     */
+    def isCapabilityName(n : String) : Boolean =
+        capabilityNames(n)
+
     /**
      * Case class and map that stores primitives metadata.
      */

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
@@ -55,8 +55,12 @@ ArgumentType =
   (IdnDef sp ":")? Expression.
 
 CapName =
-    'Reader'    {ReaderT}
-  | 'Writer'    {WriterT}.
+    'HttpDelete'    {HttpDeleteT}
+  | 'HttpGet'       {HttpGetT}
+  | 'HttpPost'      {HttpPostT}
+  | 'HttpPut'       {HttpPutT}
+  | 'Reader'        {ReaderT}
+  | 'Writer'        {WriterT}.
 
 Case =
   \n "case" Identifier '(' IdnDef ")" '=>' nestnl(Expression).

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -111,11 +111,15 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
             config.output().emit(s"  ${argument.idnDef.identifier}: ")
             def aux(t : Expression) : Seq[String] =
                 t match {
-                    case Cat(e1, e2)     => aux(e1) ++ aux(e2)
-                    case CapT(ReaderT()) => Seq("a reader")
-                    case StrT()          => Seq("a string")
-                    case CapT(WriterT()) => Seq("a writer")
-                    case t               => Seq(s"unsupported argument type ${show(t)}")
+                    case CapT(HttpDeleteT()) => Seq("a HTTP client (DELETE)")
+                    case CapT(HttpGetT())    => Seq("a HTTP client (GET)")
+                    case CapT(HttpPostT())   => Seq("a HTTP client (POST)")
+                    case CapT(HttpPutT())    => Seq("a HTTP client (PUT)")
+                    case CapT(ReaderT())     => Seq("a reader")
+                    case CapT(WriterT())     => Seq("a writer")
+                    case Cat(e1, e2)         => aux(e1) ++ aux(e2)
+                    case StrT()              => Seq("a string")
+                    case t                   => Seq(s"unsupported argument type ${show(t)}")
                 }
             val description = aux(argument.expression).mkString(", ")
             config.output().emit(description)

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Primitives.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Primitives.scala
@@ -204,7 +204,7 @@ object Primitives {
     case class HttpClientP[I <: Backend](
         method : String,
         url : String,
-        service: HttpService = (method: String, url: String) => {
+        service : HttpService = (method : String, url : String) => {
             val response = Http(url).method(method).asString
             (response.code, response.body)
         }

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Primitives.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Primitives.scala
@@ -197,17 +197,9 @@ object Primitives {
 
     }
 
-    trait HttpService {
-        def request(method : String, url : String) : (Int, String)
-    }
-
     case class HttpClientP[I <: Backend](
         method : String,
-        url : String,
-        service : HttpService = (method : String, url : String) => {
-            val response = Http(url).method(method).asString
-            (response.code, response.body)
-        }
+        url : String
     ) extends Primitive[I] {
         val numArgs = 1
 
@@ -215,7 +207,10 @@ object Primitives {
             val x = xs.head
             interp.isStrR(interp.lookupR(rho, x)) match {
                 case Some(suffix) =>
-                    val (code, body) = service.request(method, url + suffix)
+                    val (code, body) = {
+                        val response = Http(url + suffix).method(method).asString
+                        (response.code, response.body)
+                    }
                     interp.recR(Vector(
                         interp.fldR("code", interp.intR(code)),
                         interp.fldR("body", interp.strR(body))

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Primitives.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Primitives.scala
@@ -14,6 +14,7 @@ import java.io._
 
 import org.bitbucket.inkytonik.cooma.Util.fresh
 import org.bitbucket.inkytonik.cooma.exceptions.CapabilityException
+import scalaj.http.Http
 
 object Primitives {
 
@@ -106,6 +107,16 @@ object Primitives {
             }
 
             name match {
+                case "HttpDelete" | "HttpGet" | "HttpPost" | "HttpPut" =>
+                    val method = name.substring(4)
+                    try {
+                        makeCapability(Vector((
+                            method.toLowerCase,
+                            interp.httpClientP(method.toUpperCase, argument)
+                        )))
+                    } catch {
+                        case capE : CapabilityException => interp.errR(capE.getMessage)
+                    }
                 case "Writer" =>
                     try {
                         makeCapability(Vector(("write", interp.writerWriteP(argument))))
@@ -184,6 +195,26 @@ object Primitives {
 
         def show = s"consoleWrite $filename"
 
+    }
+
+    case class HttpClientP[I <: Backend](method : String, url : String) extends Primitive[I] {
+        val numArgs = 1
+
+        def run(interp : I)(rho : interp.Env, xs : Seq[String], args : Seq[String]) : interp.ValueR = {
+            val x = xs.head
+            interp.isStrR(interp.lookupR(rho, x)) match {
+                case Some(suffix) =>
+                    val response = Http(url + suffix).method(method).asString
+                    interp.recR(Vector(
+                        interp.fldR("code", interp.intR(response.code)),
+                        interp.fldR("body", interp.strR(response.body))
+                    ))
+                case None =>
+                    sys.error(s"$show: can't find string operand $x")
+            }
+        }
+
+        def show = s"httpClient ($method): $url"
     }
 
     case class RecSelectP[I <: Backend]() extends Primitive[I] {

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
@@ -638,6 +638,10 @@ class SemanticAnalyser(
             case `boolT`                    => BoolT()
             case `readerT`                  => CapT(ReaderT())
             case `writerT`                  => CapT(WriterT())
+            case `httpDeleteT`              => CapT(HttpDeleteT())
+            case `httpGetT`                 => CapT(HttpGetT())
+            case `httpPostT`                => CapT(HttpPostT())
+            case `httpPutT`                 => CapT(HttpPutT())
             case FunT(ArgumentTypes(as), t) => FunT(ArgumentTypes(as.map(aliasArgType)), alias(t))
             case RecT(fs)                   => RecT(aliasFieldTypes(fs))
             case VarT(fs)                   => VarT(aliasFieldTypes(fs))
@@ -690,6 +694,18 @@ class SemanticAnalyser(
 
             case FunT(ArgumentTypes(us), u) =>
                 unaliasFunT(n, us, u)
+
+            case CapT(HttpDeleteT()) =>
+                Some(httpDeleteT)
+
+            case CapT(HttpGetT()) =>
+                Some(httpGetT)
+
+            case CapT(HttpPostT()) =>
+                Some(httpPostT)
+
+            case CapT(HttpPutT()) =>
+                Some(httpPutT)
 
             case RecT(fieldTypes) =>
                 unaliasRecT(n, fieldTypes)

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SymbolTable.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SymbolTable.scala
@@ -73,6 +73,20 @@ object SymbolTable extends Environments[CoomaEntity] {
     val boolT : Expression =
         VarT(Vector(FieldType("False", UniT()), FieldType("True", UniT())))
 
+    private def httpT(method : String) : Expression =
+        RecT(Vector(FieldType(method, FunT(
+            ArgumentTypes(Vector(ArgumentType(Some(IdnDef("suffix")), StrT()))),
+            RecT(Vector(
+                FieldType("code", IntT()),
+                FieldType("body", StrT())
+            ))
+        ))))
+
+    val httpDeleteT : Expression = httpT("delete")
+    val httpGetT : Expression = httpT("get")
+    val httpPostT : Expression = httpT("post")
+    val httpPutT : Expression = httpT("put")
+
     val readerT : Expression =
         RecT(Vector(
             FieldType("read", FunT(ArgumentTypes(Vector()), StrT()))

--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/ReferenceBackend.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/ReferenceBackend.scala
@@ -112,6 +112,9 @@ class ReferenceBackend(
     def capabilityP(cap : String) : Primitive =
         CapabilityP(cap)
 
+    def httpClientP(method : String, url : String) : Primitive =
+        HttpClientP(method, url)
+
     def writerWriteP(filename : String) : Primitive = {
         val stdout = new StringWriter() {
             override def write(s : String) : Unit = getConfig.output().emit(s)

--- a/src/test/resources/capability/httpClientCmdArg.IR
+++ b/src/test/resources/capability/httpClientCmdArg.IR
@@ -1,0 +1,10 @@
+letv x1 = arg 0
+letv c2 = cap HttpDelete x1
+letv c3 = cap HttpGet x1
+letv c4 = concat c2 c3
+letv c5 = cap HttpPost x1
+letv c6 = concat c4 c5
+letv c7 = cap HttpPut x1
+letv httpClient = concat c6 c7
+letv u8 = {}
+$halt u8

--- a/src/test/resources/capability/httpClientCmdArg.cooma
+++ b/src/test/resources/capability/httpClientCmdArg.cooma
@@ -1,0 +1,1 @@
+fun (httpClient : HttpDelete & HttpGet & HttpPost & HttpPut) {}

--- a/src/test/resources/capability/httpClientCmdArg.usage
+++ b/src/test/resources/capability/httpClientCmdArg.usage
@@ -1,0 +1,4 @@
+arguments:
+  httpClient: a HTTP client (DELETE), a HTTP client (GET), a HTTP client (POST), a HTTP client (PUT)
+result type:
+  Unit

--- a/src/test/resources/capability/httpGet.cooma
+++ b/src/test/resources/capability/httpGet.cooma
@@ -1,0 +1,3 @@
+fun (httpClient : HttpGet) {
+    httpClient.get("")
+}

--- a/src/test/resources/capability/httpGetFoo.cooma
+++ b/src/test/resources/capability/httpGetFoo.cooma
@@ -1,0 +1,3 @@
+fun (httpClient : HttpGet) {
+    httpClient.get("/foo")
+}

--- a/src/test/resources/capability/httpGetPostPut.cooma
+++ b/src/test/resources/capability/httpGetPostPut.cooma
@@ -1,0 +1,7 @@
+fun (httpClient : HttpGet & HttpPost & HttpPut) {
+    {
+        x0 = httpClient.get("").body,
+        x1 = httpClient.post("").body,
+        x2 = httpClient.put("").body
+    }
+}

--- a/src/test/resources/capability/httpNotPermitted.cooma
+++ b/src/test/resources/capability/httpNotPermitted.cooma
@@ -1,0 +1,3 @@
+fun (httpClient : HttpGet & HttpPut) {
+    httpClient.delete("")
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/ExecutionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/ExecutionTests.scala
@@ -49,6 +49,15 @@ class ExecutionTests extends Driver with TestCompilerWithConfig[ASTNode, Program
             )
         )
 
+    val thread = new Thread(() => {
+        try {
+            HttpServer.run(Nil)
+        } catch {
+            case _ : InterruptedException => ()
+        }
+    })
+    thread.start()
+
     for (backend <- backends) {
 
         // Basic tests
@@ -1843,4 +1852,6 @@ class ExecutionTests extends Driver with TestCompilerWithConfig[ASTNode, Program
         else
             super.testdriver(config)
     }
+
+    thread.interrupt()
 }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/ExecutionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/ExecutionTests.scala
@@ -1323,7 +1323,9 @@ class ExecutionTests extends Driver with TestCompilerWithConfig[ASTNode, Program
                     OptionTest("IR print", "-i", "capability/writerCmdArg", "IR", Seq("/dev/null")),
                     OptionTest("IR AST print", "-I", "capability/writerCmdArg", "IRAST", Seq("/dev/null")),
                     OptionTest("IR print", "-i", "capability/readerWriterCmdArg", "IR", Seq("/dev/null")),
-                    OptionTest("Usage", "--usage", "capability/readerWriterCmdArg", "usage", Seq("/dev/null"))
+                    OptionTest("Usage", "--usage", "capability/readerWriterCmdArg", "usage", Seq("/dev/null")),
+                    OptionTest("IR print", "-i", "capability/httpClientCmdArg", "IR", Seq("localhost:8080")),
+                    OptionTest("Usage", "--usage", "capability/httpClientCmdArg", "usage", Seq("localhost:8080"))
                 )
 
             for (aTest <- optionTests) {

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/ExecutionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/ExecutionTests.scala
@@ -1793,14 +1793,14 @@ class ExecutionTests extends Driver with TestCompilerWithConfig[ASTNode, Program
                 val result = runFile(filename, backend.options :+ "-r", backend, args)
                 result shouldBe
                     """|src/test/resources/capability/httpNotPermitted.cooma:2:16:error: delete is not a field of record type {
-                       |    get : (suffix : String) {
-                       |        code : Int,
-                       |        body : String
-                       |    },
-                       |    put : (suffix : String) {
-                       |        code : Int,
-                       |        body : String
-                       |    }
+                       |  get : (suffix : String) {
+                       |    code : Int,
+                       |    body : String
+                       |  },
+                       |  put : (suffix : String) {
+                       |    code : Int,
+                       |    body : String
+                       |  }
                        |}
                        |    httpClient.delete("")
                        |               ^

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/HttpServer.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/HttpServer.scala
@@ -1,0 +1,35 @@
+package org.bitbucket.inkytonik.cooma
+
+import cats.effect.{ConcurrentEffect, ExitCode, IO, IOApp, Timer}
+import fs2.Stream
+import org.http4s.HttpRoutes
+import org.http4s.dsl.Http4sDsl
+import org.http4s.implicits._
+import org.http4s.server.blaze.BlazeServerBuilder
+
+import scala.concurrent.ExecutionContext.global
+
+object HttpServer extends IOApp {
+
+    override def run(args : List[String]) : IO[ExitCode] =
+        HttpServer.stream[IO].compile.drain.as(ExitCode.Success)
+
+    def stream[F[_] : ConcurrentEffect](implicit timer : Timer[F]) : Stream[F, Nothing] = {
+        val routes = {
+            val dsl = new Http4sDsl[F] {}; import dsl._
+            HttpRoutes.of[F] {
+                case DELETE -> Root      => Ok("DELETE / response")
+                case GET -> Root         => Ok("GET / response")
+                case POST -> Root        => Ok("POST / response")
+                case PUT -> Root         => Ok("PUT / response")
+                case GET -> Root / "foo" => Ok("GET /foo response")
+            }
+        }
+        BlazeServerBuilder(global)
+            .bindHttp(8080, "0.0.0.0")
+            .withHttpApp(routes.orNotFound)
+            .serve
+            .drain
+    }
+
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/SemanticTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/SemanticTests.scala
@@ -507,6 +507,23 @@ class SemanticTests extends Tests {
                    |"""
             ),
             SemanticTest(
+                "HttpGet is a record with a get field",
+                "fun (httpClient : HttpGet) httpClient.get(\"\")",
+                ""
+            ),
+            SemanticTest(
+                "HttpDelete & HttpGet & HttpPost & HttpPut is a record with the respective fields",
+                """|fun (httpClient : HttpDelete & HttpGet & HttpPost & HttpPut) {
+                   |    val _ = httpClient.delete("")
+                   |    val _ = httpClient.get("")
+                   |    val _ = httpClient.post("")
+                   |    val _ = httpClient.put("")
+                   |    {}
+                   |}
+                   |""".stripMargin,
+                ""
+            ),
+            SemanticTest(
                 "Reader is a record with a read field",
                 "fun (r : Reader) r.read()",
                 ""

--- a/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleBackend.scala
+++ b/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleBackend.scala
@@ -102,6 +102,9 @@ class TruffleBackend(config : Config) extends Backend {
     def capabilityP(cap : String) : Primitive =
         CapabilityP(cap)
 
+    def httpClientP(method : String, url : String) : Primitive =
+        HttpClientP(method, url)
+
     def writerWriteP(filename : String) : Primitive =
         WriterWriteP(filename, new PrintWriter(System.out))
 


### PR DESCRIPTION
This PR introduces network capabilities, as requested in #22.

### Overview

Four new command-line parameter types are defined – `HttpDelete`, `HttpGet`, `HttpPost`, and `HttpPut`. Structurally, each of these is a record type with a single attribute, named `delete`, `get`, `post`, and `put` respectively. Each of these attributes has the type `(String) { code : Int, body : String }`.

If `httpClient: HttpGet` was initialised with a command-line argument `root`, then invoking `httpClient.get(suffix)` will send a HTTP request with the `GET` method to the address given by the string concatenation of `root` and `suffix`. The function will return a record containing the status code (`code`) of the request and the body (`body`). The behaviour of each of the other three types is the same, except a different HTTP method is used. Thus the user has discretion over what URLs the HTTP client may make requests too.

Using type-level record concatenation, the programmer can specify that a HTTP client should be able to invoke multiple methods. For example, if `httpClient: HttpGet & HttpPut` is a command-line parameter, then `httpClient` will have both the `get` and `put` attributes. Both will make requests using the same root URL.

### Examples

In each example, assume the program is executed with the command-line argument `http://www.example.com`.

---

```
fun (httpClient : HttpGet) {
    httpClient.get("")
}
```

Running this program will send a `GET` request to `http://www.example.com` and return the status code and body of the response.

---

```
fun (httpClient : HttpGet) {
    httpClient.get("/foo")
}
```

Running this program will make a `GET` request to `http://www.example.com/foo` and return the status code and body of the response.

---

```
fun (httpClient : HttpGet & HttpPost & HttpPut) {
    val _ = httpClient.post("/foo")
    val _ = httpClient.put("/bar")
    httpClient.get("/baz").body
}
```

Running this program will make `POST` request to `http://www.example.com/foo`, then a `PUT` request to `http://www.example.com/bar`, and then a `GET` request to `http://www.example.com/baz`. The body of the `GET` response will be returned.
