### PR TITLE
Define capability node in the AST

### DIFF
--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
@@ -39,12 +39,6 @@ trait Compiler {
     }
 
     /**
-     * Name of capability type?
-     */
-    def isCapabilityName(n : String) : Boolean =
-        (n == "Writer") || (n == "Reader")
-
-    /**
      * Case class and map that stores primitives metadata.
      */
     case class PrimitiveMeta(prm : Primitive)
@@ -117,10 +111,8 @@ trait Compiler {
                         t match {
                             case Cat(e1, e2) =>
                                 aux(e1) ::: aux(e2)
-                            case ReaderT() =>
-                                "Reader" :: Nil
-                            case WriterT() =>
-                                "Writer" :: Nil
+                            case CapT(name) =>
+                                name.productPrefix.init :: Nil
                             case t =>
                                 sys.error(s"compileTopArg: ${show(t)} arguments not supported")
                         }
@@ -367,7 +359,7 @@ trait Compiler {
     object IsType {
         def unapply(e : Expression) : Boolean =
             e match {
-                case BoolT() | ReaderT() | WriterT() |
+                case BoolT() | CapT(_) |
                     _ : FunT | _ : IntT | _ : RecT | _ : StrT | _ : TypT |
                     _ : UniT | _ : VarT =>
                     true

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
@@ -33,8 +33,7 @@ Expression {paren} =
   | IntLit                                                   {Num, 1: BigInt.apply : BigInt}
   | 'Int'                                                    {IntT}
   | 'Ints'                                                   {Ints}
-  | 'Reader'                                                 {ReaderT}
-  | 'Writer'                                                 {WriterT}
+  | CapName                                                  {CapT}
   | StringLit                                                {Str}
   | 'String'                                                 {StrT}
   | 'Strings'                                                {Strings}
@@ -54,6 +53,10 @@ ArgumentTypes =
 
 ArgumentType =
   (IdnDef sp ":")? Expression.
+
+CapName =
+    'Reader'    {ReaderT}
+  | 'Writer'    {WriterT}.
 
 Case =
   \n "case" Identifier '(' IdnDef ")" '=>' nestnl(Expression).

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -111,11 +111,11 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
             config.output().emit(s"  ${argument.idnDef.identifier}: ")
             def aux(t : Expression) : Seq[String] =
                 t match {
-                    case Cat(e1, e2) => aux(e1) ++ aux(e2)
-                    case ReaderT()   => Seq("a reader")
-                    case StrT()      => Seq("a string")
-                    case WriterT()   => Seq("a writer")
-                    case t           => Seq(s"unsupported argument type ${show(t)}")
+                    case Cat(e1, e2)     => aux(e1) ++ aux(e2)
+                    case CapT(ReaderT()) => Seq("a reader")
+                    case StrT()          => Seq("a string")
+                    case CapT(WriterT()) => Seq("a writer")
+                    case t               => Seq(s"unsupported argument type ${show(t)}")
                 }
             val description = aux(argument.expression).mkString(", ")
             config.output().emit(description)

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
@@ -134,8 +134,8 @@ trait REPL extends REPLBase[Config] {
     object AlreadyBoundIdn {
         def unapply(e : Expression) : Boolean =
             e match {
-                case BoolT() | Booleans() | False() | Idn(IdnUse(_)) | IntT() | Ints() |
-                    ReaderT() | WriterT() | Strings() | StrT() | True() =>
+                case BoolT() | Booleans() | CapT(_) | False() | Idn(IdnUse(_)) | IntT() | Ints() |
+                    Strings() | StrT() | True() =>
                     true
                 case _ =>
                     false

--- a/src/test/resources/capability/writerCmdArg.coomaAST
+++ b/src/test/resources/capability/writerCmdArg.coomaAST
@@ -5,7 +5,8 @@ Program(
         Argument(
           IdnDef(
             "w"),
-          WriterT(),
+          CapT(
+            WriterT()),
           None))),
     App(
       Sel(


### PR DESCRIPTION
The key change in this PR is a new AST node:

```
CapName =
    'Reader'    {ReaderT}
  | 'Writer'    {WriterT}.
```

This helps to reduce boilerplate in various places, for example in identifying if an expression refers to a type.
