### PR TITLE
Remove primitive types from syntax

### DIFF
--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
@@ -20,7 +20,6 @@ Expression {paren} =
   | Expression '(' Expression ** "," ')'                     {App, left, 1}
   | Expression '.' FieldUse                                  {Sel, left, 1}
   | '{' '}'                                                  {Uni}
-  | 'Unit'                                                   {UniT}
   | '{' nestnl(BlockExp) \n '}'                              {Blk}
   | '{' nest(Field ++ ',') \n '}'                            {Rec}
   | '{' nest(FieldType ++ ',') \n '}'                        {RecT}
@@ -31,13 +30,10 @@ Expression {paren} =
   | 'Boolean'                                                {BoolT}
   | 'Booleans'                                               {Booleans}
   | IntLit                                                   {Num, 1: BigInt.apply : BigInt}
-  | 'Int'                                                    {IntT}
   | 'Ints'                                                   {Ints}
   | CapName                                                  {CapT}
   | StringLit                                                {Str}
-  | 'String'                                                 {StrT}
   | 'Strings'                                                {Strings}
-  | 'Type'                                                   {TypT}
   | 'equal'                                                  {Eql}
   | "prim" Identifier '(' Expression ** "," ')'              {Prm}
   | IdnUse                                                   {Idn}.

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -17,6 +17,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
 
     import org.bitbucket.inkytonik.cooma.CoomaParserPrettyPrinter.{any, layout, pretty, show}
     import org.bitbucket.inkytonik.cooma.CoomaParserSyntax._
+    import org.bitbucket.inkytonik.cooma.SymbolTable.strT
     import org.bitbucket.inkytonik.kiama.output.PrettyPrinterTypes.Document
     import org.bitbucket.inkytonik.kiama.relation.Tree
     import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, noMessages}
@@ -113,7 +114,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
                 t match {
                     case Cat(e1, e2)     => aux(e1) ++ aux(e2)
                     case CapT(ReaderT()) => Seq("a reader")
-                    case StrT()          => Seq("a string")
+                    case `strT`          => Seq("a string")
                     case CapT(WriterT()) => Seq("a writer")
                     case t               => Seq(s"unsupported argument type ${show(t)}")
                 }

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
@@ -134,8 +134,8 @@ trait REPL extends REPLBase[Config] {
     object AlreadyBoundIdn {
         def unapply(e : Expression) : Boolean =
             e match {
-                case BoolT() | Booleans() | CapT(_) | False() | Idn(IdnUse(_)) | IntT() | Ints() |
-                    Strings() | StrT() | True() =>
+                case BoolT() | Booleans() | CapT(_) | False() | Idn(IdnUse(_)) | Ints() |
+                    Strings() | True() =>
                     true
                 case _ =>
                     false
@@ -243,7 +243,7 @@ trait REPL extends REPLBase[Config] {
         config : Config,
         eval : => Unit
     ) =
-        if (aliasedType == TypT())
+        if (aliasedType == typT)
             output(i, optTypeValue, aliasedType, None, config)
         else
             eval
@@ -260,7 +260,7 @@ trait REPL extends REPLBase[Config] {
     ) : Unit = {
         val value =
             aliasedType match {
-                case TypT() =>
+                case `typT` =>
                     optTypeValue match {
                         case Some(typeValue) =>
                             s" = ${show(typeValue)}"

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
@@ -26,13 +26,15 @@ class SemanticAnalyser(
     import org.bitbucket.inkytonik.kiama.util.Messaging.{check, collectMessages, error, Messages, noMessages}
     import org.bitbucket.inkytonik.cooma.CoomaParserPrettyPrinter.show
     import org.bitbucket.inkytonik.cooma.CoomaParserSyntax._
-    import org.bitbucket.inkytonik.cooma.SymbolTable.primitivesTypesTable
 
     val decorators = new Decorators(tree)
     import decorators._
 
     lazy val errors : Messages =
         collectMessages(tree) {
+            case i @ IdnDef(s) if isPrimitiveTypeName(s) =>
+                error(i, s"$s is a reserved primitive type name")
+
             case tree.parent.pair(d @ IdnDef(i), p) =>
                 lookup(env(p), i, UnknownEntity()) match {
                     case MultipleEntity() =>
@@ -58,6 +60,8 @@ class SemanticAnalyser(
                             checkApplication(f, as)
                         case a @ Cat(l, r) =>
                             checkConcat(a, l, r)
+                        case PrimitiveType() =>
+                            noMessages
                         case Idn(u @ IdnUse(i)) if entity(u) == UnknownEntity() =>
                             error(u, s"$i is not declared")
                         case Mat(e, cs) =>
@@ -168,7 +172,7 @@ class SemanticAnalyser(
             case (Some(RecT(_)), Some(t)) =>
                 // term-level concatenation, invalid right operand
                 error(r, s"expected record, got ${show(alias(t))}")
-            case (Some(TypT()), Some(TypT())) =>
+            case (Some(`typT`), Some(`typT`)) =>
                 // type-level concatenation
                 (unalias(e, l), unalias(e, r)) match {
                     case (None, _) | (_, None) =>
@@ -180,7 +184,7 @@ class SemanticAnalyser(
                     case (Some(t), _) =>
                         error(l, s"expected record type, got ${show(alias(t))}")
                 }
-            case (Some(TypT()), Some(t)) =>
+            case (Some(`typT`), Some(t)) =>
                 // type-level concatenation, invalid right operand
                 error(r, s"expected record type, got ${show(alias(t))}")
             case (Some(t), _) =>
@@ -239,7 +243,7 @@ class SemanticAnalyser(
     def checkMainArgument(arg : Argument) : Messages = {
         def aux(t : Expression) : Boolean =
             t match {
-                case CapT(_) | StrT() => true
+                case CapT(_) | `strT` => true
                 case Cat(l, r)        => aux(l) && aux(r)
                 case _                => false
             }
@@ -402,10 +406,10 @@ class SemanticAnalyser(
                 )))
 
             case BoolT() =>
-                Some(TypT())
+                Some(typT)
 
             case CapT(_) =>
-                Some(TypT())
+                Some(typT)
 
             case n @ Cat(e1, e2) =>
                 (tipe(e1), tipe(e2)) match {
@@ -414,11 +418,11 @@ class SemanticAnalyser(
                             Some(RecT(r1 ++ r2))
                         else
                             None
-                    case (Some(TypT()), Some(TypT())) =>
+                    case (Some(`typT`), Some(`typT`)) =>
                         (unalias(n, e1), unalias(n, e2)) match {
                             case (Some(RecT(r1)), Some(RecT(r2))) =>
                                 if (overlappingFields(r1, r2).isEmpty)
-                                    Some(TypT())
+                                    Some(typT)
                                 else
                                     None
                             case _ =>
@@ -431,7 +435,7 @@ class SemanticAnalyser(
             case _ : Eql =>
                 Some(FunT(
                     ArgumentTypes(Vector(
-                        ArgumentType(Some(IdnDef("t")), TypT()),
+                        ArgumentType(Some(IdnDef("t")), typT),
                         ArgumentType(None, Idn(IdnUse("t"))),
                         ArgumentType(None, Idn(IdnUse("t"))),
                     )),
@@ -450,7 +454,10 @@ class SemanticAnalyser(
                 }
 
             case _ : FunT =>
-                Some(TypT())
+                Some(typT)
+
+            case PrimitiveType() =>
+                Some(typT)
 
             case u @ Idn(IdnUse(x)) =>
                 entityType(lookup(env(u), x, UnknownEntity()))
@@ -469,9 +476,6 @@ class SemanticAnalyser(
                     FieldType("gte", primitivesTypesTable("IntGte"))
                 )))
 
-            case IntT() =>
-                Some(TypT())
-
             case m : Mat =>
                 matchType(m) match {
                     case OkCases(optType) =>
@@ -481,7 +485,7 @@ class SemanticAnalyser(
                 }
 
             case _ : Num =>
-                Some(IntT())
+                Some(intT)
 
             case n @ Prm(i, args) =>
                 primitivesTypesTable.get(i) match {
@@ -498,7 +502,7 @@ class SemanticAnalyser(
                 makeRow(fields).map(RecT)
 
             case _ : RecT =>
-                Some(TypT())
+                Some(typT)
 
             case Sel(r, FieldUse(f)) =>
                 tipe(r) match {
@@ -517,7 +521,7 @@ class SemanticAnalyser(
                 }
 
             case _ : Str =>
-                Some(StrT())
+                Some(strT)
 
             case Strings() =>
                 Some(RecT(Vector(
@@ -526,26 +530,17 @@ class SemanticAnalyser(
                     FieldType("substr", primitivesTypesTable("StrSubstr"))
                 )))
 
-            case StrT() =>
-                Some(TypT())
-
             case True() =>
                 Some(boolT)
 
-            case TypT() =>
-                Some(TypT())
-
             case Uni() =>
-                Some(UniT())
-
-            case UniT() =>
-                Some(TypT())
+                Some(uniT)
 
             case Var(field) =>
                 makeRow(Vector(field)).map(VarT)
 
             case _ : VarT =>
-                Some(TypT())
+                Some(typT)
         }
 
     def substArgTypes[T](x : String, t : Expression, a : T) = {
@@ -567,7 +562,7 @@ class SemanticAnalyser(
             None
         else
             ts.head match {
-                case ArgumentType(Some(IdnDef(x)), TypT()) =>
+                case ArgumentType(Some(IdnDef(x)), `typT`) =>
                     appType(f, substArgTypes(x, as.head, ts.tail), substArgTypes(x, as.head, t), as.tail)
                 case _ =>
                     appType(f, ts.tail, t, as.tail)
@@ -678,9 +673,12 @@ class SemanticAnalyser(
                         None
                 }
 
+            case PrimitiveType() =>
+                Some(t)
+
             case Idn(IdnUse(x)) =>
                 lookup(env(n), x, UnknownEntity()) match {
-                    case ArgumentEntity(Argument(_, TypT(), _)) =>
+                    case ArgumentEntity(Argument(_, `typT`, _)) =>
                         Some(t)
                     case LetEntity(Let(_, _, _, v)) if t != v =>
                         unalias(n, v)
@@ -777,32 +775,32 @@ class SemanticAnalyser(
                 }
 
             case tree.parent(_ : Argument) =>
-                Some(TypT())
+                Some(typT)
 
             case tree.parent(_ : ArgumentType) =>
-                Some(TypT())
+                Some(typT)
 
             case tree.parent.pair(a, Body(_, t, e)) =>
                 if (a eq t)
-                    Some(TypT())
+                    Some(typT)
                 else
                     unalias(e, t)
 
             case tree.parent(_ : FieldType) =>
-                Some(TypT())
+                Some(typT)
 
             case tree.parent(_ : FunT) =>
-                Some(TypT())
+                Some(typT)
 
             case tree.parent.pair(a : Expression, Let(_, _, Some(t), e)) =>
                 if (a eq t)
-                    Some(TypT())
+                    Some(typT)
                 else
                     unalias(e, t)
 
             case tree.parent.pair(a : Expression, Prm("Equal", Vector(t, l, r))) =>
                 if (a eq t)
-                    Some(TypT())
+                    Some(typT)
                 else
                     unalias(t, t)
 

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SymbolTable.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SymbolTable.scala
@@ -70,17 +70,42 @@ object SymbolTable extends Environments[CoomaEntity] {
         override val isError = true
     }
 
+    // Short-hands for primitive types
+
+    val intT : Expression = Idn(IdnUse("Int"))
+    val strT : Expression = Idn(IdnUse("String"))
+    val typT : Expression = Idn(IdnUse("Type"))
+    val uniT : Expression = Idn(IdnUse("Unit"))
+
+    def isPrimitiveTypeName(s : String) : Boolean =
+        (s == "Int") | (s == "String") | (s == "Type") | (s == "Unit")
+
+    object PrimitiveType {
+        def unapply(e : Expression) : Boolean =
+            e match {
+                case Idn(IdnUse(s)) if isPrimitiveTypeName(s) =>
+                    true
+                case _ =>
+                    false
+            }
+    }
+
+    object PrimitiveTypeName {
+        def unapply(s : String) : Boolean =
+            PrimitiveType.unapply(Idn(IdnUse(s)))
+    }
+
     val boolT : Expression =
-        VarT(Vector(FieldType("False", UniT()), FieldType("True", UniT())))
+        VarT(Vector(FieldType("False", uniT), FieldType("True", uniT)))
 
     val readerT : Expression =
         RecT(Vector(
-            FieldType("read", FunT(ArgumentTypes(Vector()), StrT()))
+            FieldType("read", FunT(ArgumentTypes(Vector()), strT))
         ))
 
     val writerT : Expression =
         RecT(Vector(
-            FieldType("write", FunT(ArgumentTypes(Vector(ArgumentType(Some(IdnDef("s")), StrT()))), UniT()))
+            FieldType("write", FunT(ArgumentTypes(Vector(ArgumentType(Some(IdnDef("s")), strT))), uniT))
         ))
 
     def mkPrimType(args : Vector[Expression], retType : Expression) : FunT =
@@ -90,26 +115,26 @@ object SymbolTable extends Environments[CoomaEntity] {
         FunT(ArgumentTypes(args.map { case (x, e) => ArgumentType(Some(IdnDef(x)), e) }), retType)
 
     def mkIntUnPrimType(retType : Expression) : FunT =
-        mkPrimType(Vector(IntT()), retType)
+        mkPrimType(Vector(intT), retType)
 
     def mkIntBinPrimType(retType : Expression) : FunT =
-        mkPrimType(Vector(IntT(), IntT()), retType)
+        mkPrimType(Vector(intT, intT), retType)
 
     val primitivesTypesTable = Map(
-        "Equal" -> mkPrimTypeWithArgNames(Vector(("t", TypT()), ("l", Idn(IdnUse("t"))), ("l", Idn(IdnUse("t")))), boolT),
-        "IntAbs" -> mkIntUnPrimType(IntT()),
-        "IntAdd" -> mkIntBinPrimType(IntT()),
-        "IntSub" -> mkIntBinPrimType(IntT()),
-        "IntMul" -> mkIntBinPrimType(IntT()),
-        "IntDiv" -> mkIntBinPrimType(IntT()),
-        "IntPow" -> mkIntBinPrimType(IntT()),
+        "Equal" -> mkPrimTypeWithArgNames(Vector(("t", typT), ("l", Idn(IdnUse("t"))), ("l", Idn(IdnUse("t")))), boolT),
+        "IntAbs" -> mkIntUnPrimType(intT),
+        "IntAdd" -> mkIntBinPrimType(intT),
+        "IntSub" -> mkIntBinPrimType(intT),
+        "IntMul" -> mkIntBinPrimType(intT),
+        "IntDiv" -> mkIntBinPrimType(intT),
+        "IntPow" -> mkIntBinPrimType(intT),
         "IntGt" -> mkIntBinPrimType(boolT),
         "IntGte" -> mkIntBinPrimType(boolT),
         "IntLt" -> mkIntBinPrimType(boolT),
         "IntLte" -> mkIntBinPrimType(boolT),
-        "StrConcat" -> mkPrimType(Vector(StrT(), StrT()), StrT()),
-        "StrLength" -> mkPrimType(Vector(StrT()), IntT()),
-        "StrSubstr" -> mkPrimType(Vector(StrT(), IntT()), StrT())
+        "StrConcat" -> mkPrimType(Vector(strT, strT), strT),
+        "StrLength" -> mkPrimType(Vector(strT), intT),
+        "StrSubstr" -> mkPrimType(Vector(strT, intT), strT)
     )
 
 }

--- a/src/test/resources/basic/blockDef.coomaAST
+++ b/src/test/resources/basic/blockDef.coomaAST
@@ -12,9 +12,13 @@ Program(
                   Argument(
                     IdnDef(
                       "x"),
-                    IntT(),
+                    Idn(
+                      IdnUse(
+                        "Int")),
                     None))),
-              IntT(),
+              Idn(
+                IdnUse(
+                  "Int")),
               Idn(
                 IdnUse(
                   "x")))),
@@ -27,9 +31,13 @@ Program(
                   Argument(
                     IdnDef(
                       "y"),
-                    IntT(),
+                    Idn(
+                      IdnUse(
+                        "Int")),
                     None))),
-              IntT(),
+              Idn(
+                IdnUse(
+                  "Int")),
               App(
                 Idn(
                   IdnUse(

--- a/src/test/resources/basic/multiArgCall.coomaAST
+++ b/src/test/resources/basic/multiArgCall.coomaAST
@@ -8,12 +8,16 @@ Program(
               Argument(
                 IdnDef(
                   "x"),
-                IntT(),
+                Idn(
+                  IdnUse(
+                    "Int")),
                 None),
               Argument(
                 IdnDef(
                   "y"),
-                StrT(),
+                Idn(
+                  IdnUse(
+                    "String")),
                 None))),
           Idn(
             IdnUse(

--- a/src/test/resources/basic/singleArgCall.coomaAST
+++ b/src/test/resources/basic/singleArgCall.coomaAST
@@ -8,7 +8,9 @@ Program(
               Argument(
                 IdnDef(
                   "x"),
-                IntT(),
+                Idn(
+                  IdnUse(
+                    "Int")),
                 None))),
           Idn(
             IdnUse(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/SemanticTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/SemanticTests.scala
@@ -166,6 +166,38 @@ class SemanticTests extends Tests {
             // Uses
 
             SemanticTest(
+                "Int can't be used as user identifier",
+                "{ val Int = 0 1 }",
+                """|1:7:error: Int is a reserved primitive type name
+                   |{ val Int = 0 1 }
+                   |      ^
+                   |"""
+            ),
+            SemanticTest(
+                "String can't be used as user identifier",
+                "{ val String = 0 1 }",
+                """|1:7:error: String is a reserved primitive type name
+                   |{ val String = 0 1 }
+                   |      ^
+                   |"""
+            ),
+            SemanticTest(
+                "Type can't be used as user identifier",
+                "{ val Type = 0 1 }",
+                """|1:7:error: Type is a reserved primitive type name
+                   |{ val Type = 0 1 }
+                   |      ^
+                   |"""
+            ),
+            SemanticTest(
+                "Unit can't be used as user identifier",
+                "{ val Unit = 0 1 }",
+                """|1:7:error: Unit is a reserved primitive type name
+                   |{ val Unit = 0 1 }
+                   |      ^
+                   |"""
+            ),
+            SemanticTest(
                 "val not usable in its own type",
                 "{ val x : x = 0 1 }",
                 """|1:11:error: x is not declared


### PR DESCRIPTION
Int, String, Type and Unit are now represented as identifiers
rather than with their own syntactic constructs. Unlike normal
defined identifiers, they can't be re-defined in a program.