### PR TITLE
refactor: make Primitives a mixin trait

### DIFF
--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/Interpreter.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/Interpreter.scala
@@ -171,7 +171,7 @@ class Interpreter(config : Config) extends PrettyPrinter {
                     IntR(i)
 
                 case PrmV(p, xs) =>
-                    p.eval(this)(rho, xs, args)
+                    p.eval(rho, xs, args)
 
                 case RecV(fields) =>
                     RecR(fields.map {

--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/ReferenceBackend.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/ReferenceBackend.scala
@@ -18,17 +18,14 @@ class ReferenceBackend(
     val driver : Driver,
     val source : Source,
     config : Config
-) extends Interpreter(config) with Backend {
+) extends Interpreter(config) with Backend with Primitives[ReferenceBackend] {
 
     import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.ASTNode
-    import org.bitbucket.inkytonik.cooma.Primitives._
     import org.bitbucket.inkytonik.cooma.Util.escape
     import org.bitbucket.inkytonik.kiama.output.PrettyPrinterTypes.{Document, Width}
     import org.bitbucket.inkytonik.kiama.relation.Bridge
 
     override def backendName : String = "Reference"
-
-    type Primitive = org.bitbucket.inkytonik.cooma.Primitives.Primitive[ReferenceBackend]
 
     sealed abstract class Value
     case class FunV(k : String, x : String, body : Term) extends Value
@@ -141,13 +138,13 @@ class ReferenceBackend(
         EqualP()
 
     def intBinP(op : Primitives.IntPrimBinOp) : Primitive =
-        Primitives.IntBinOp(op)
+        IntBinOp(op)
 
     def intRelP(op : Primitives.IntPrimRelOp) : Primitive =
-        Primitives.IntRelOp(op)
+        IntRelOp(op)
 
     def stringP(op : Primitives.StrPrimOp) : Primitive =
-        Primitives.StringPrimitive(op)
+        StringPrimitive(op)
 
     // Runtime values
 

--- a/truffle/src/main/java/org/bitbucket/inkytonik/cooma/truffle/nodes/value/CoomaPrimitiveValue.java
+++ b/truffle/src/main/java/org/bitbucket/inkytonik/cooma/truffle/nodes/value/CoomaPrimitiveValue.java
@@ -13,8 +13,6 @@ package org.bitbucket.inkytonik.cooma.truffle.nodes.value;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.bitbucket.inkytonik.cooma.Backend;
 import org.bitbucket.inkytonik.cooma.Primitives.Primitive;
 import org.bitbucket.inkytonik.cooma.truffle.runtime.RuntimeValue;
 import scala.jdk.javaapi.CollectionConverters;
@@ -22,19 +20,23 @@ import scala.jdk.javaapi.CollectionConverters;
 import java.util.Arrays;
 
 @Getter
-@RequiredArgsConstructor
 @NodeInfo(shortName = "prmV", description = "Primitive value")
 public class CoomaPrimitiveValue extends CoomaValueNode {
 
-	private final Backend backend;
 	private final Primitive p;
 	private final String[] xs;
 
+	public CoomaPrimitiveValue(Object p, String[] xs) {
+		if (!(p instanceof Primitive)) {
+			throw new RuntimeException("expected Primitive instance");
+		}
+		this.p = (Primitive) p;
+		this.xs = xs;
+	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public RuntimeValue evaluate(VirtualFrame frame) {
-		return (RuntimeValue) p.eval(backend, obtainRho(),
+		return (RuntimeValue) p.eval(obtainRho(),
 				CollectionConverters.asScala(Arrays.asList(xs)).toVector(),
 				CollectionConverters.asScala(Arrays.asList(getArgs()).iterator()).toVector());
 	}

--- a/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleBackend.scala
+++ b/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleBackend.scala
@@ -10,9 +10,9 @@
 
 package org.bitbucket.inkytonik.cooma.truffle
 
-import org.bitbucket.inkytonik.cooma.{Backend, Config}
+import org.bitbucket.inkytonik.cooma.{Backend, Config, Primitives}
 
-class TruffleBackend(config : Config) extends Backend {
+class TruffleBackend(config : Config) extends Backend with Primitives[TruffleBackend] {
 
     import java.io.PrintWriter
     import java.math.BigInteger
@@ -71,7 +71,7 @@ class TruffleBackend(config : Config) extends Backend {
         new CoomaIntValueNode(i.bigInteger)
 
     def prmV(p : Primitive, xs : Vector[String]) : Value =
-        new CoomaPrimitiveValue(this, p, xs.toArray)
+        new CoomaPrimitiveValue(p, xs.toArray)
 
     def recV(fs : Vector[FieldValue]) : Value =
         new CoomaRecValueNode(fs.toArray)
@@ -95,8 +95,6 @@ class TruffleBackend(config : Config) extends Backend {
      */
     def showTerm(t : Term) : String =
         t.toString
-
-    type Primitive = org.bitbucket.inkytonik.cooma.Primitives.Primitive[TruffleBackend]
 
     def argumentP(i : Int) : Primitive =
         ArgumentP(i)


### PR DESCRIPTION
This PR simplifies the definitions of primitives.

The existing `Primitives.scala` requires every primitive class to have a type parameter '`I <: Backend`' and every method of these classes to have a parameter block '`(interp: I)`', with fields of `interp` (including types) frequently accessed.

The key change proposed in this PR is to change `Primitives` from an object to a trait that is mixed in with a `Backend`. This eliminates the type parameters, the extra parameter block, and all accesses on `interp`.

The only complication I ran into is in `CoomaPrimitiveValue.java` for Truffle, which seems to arise from some Scala-to-Java weirdness with mixins and inner classes. I explored some possible type-safe fixes, but was unable to find one. I have resolved this using a type coercion.