### PR TITLE
Monadic error handling for IO capabilities

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,1 @@
--J-Xss4m
+-J-Xss8m

--- a/prelude/prelude.cooma
+++ b/prelude/prelude.cooma
@@ -60,11 +60,11 @@
   // Capability types
 
   type FolderReader = {
-    read : (suffix : String) String
+    read : (suffix : String) <Left : String, Right : String>
   }
 
   type FolderWriter = {
-    write : (suffix : String, s : String) Unit
+    write : (suffix : String, s : String) <Left : String, Right : Unit>
   }
 
   type HttpReturn = {
@@ -73,27 +73,27 @@
   }
 
   type HttpDelete = {
-    delete : (suffix : String) HttpReturn
+    delete : (suffix : String) <Left : String, Right : HttpReturn>
   }
 
   type HttpGet = {
-    get : (suffix : String) HttpReturn
+    get : (suffix : String) <Left : String, Right : HttpReturn>
   }
 
   type HttpPost = {
-    post : (suffix : String) HttpReturn
+    post : (suffix : String) <Left : String, Right : HttpReturn>
   }
 
   type HttpPut = {
-    put : (suffix : String) HttpReturn
+    put : (suffix : String) <Left : String, Right : HttpReturn>
   }
 
   type Reader = {
-    read : () String
+    read : () <Left : String, Right : String>
   }
 
   type Writer = {
-    write : (s : String) Unit
+    write : (s : String) <Left : String, Right : Unit>
   }
 
   // Useful type constructors

--- a/prelude/prelude.cooma.static
+++ b/prelude/prelude.cooma.static
@@ -92,12 +92,18 @@ Vectors :
 FolderReader :
   Type =
   {
-    read : (suffix : String) String
+    read : (suffix : String) <
+      Left : String,
+      Right : String
+    >
   };
 FolderWriter :
   Type =
   {
-    write : (suffix : String, s : String) Unit
+    write : (suffix : String, s : String) <
+      Left : String,
+      Right : Unit
+    >
   };
 HttpReturn :
   Type =
@@ -108,32 +114,50 @@ HttpReturn :
 HttpDelete :
   Type =
   {
-    delete : (suffix : String) HttpReturn
+    delete : (suffix : String) <
+      Left : String,
+      Right : HttpReturn
+    >
   };
 HttpGet :
   Type =
   {
-    get : (suffix : String) HttpReturn
+    get : (suffix : String) <
+      Left : String,
+      Right : HttpReturn
+    >
   };
 HttpPost :
   Type =
   {
-    post : (suffix : String) HttpReturn
+    post : (suffix : String) <
+      Left : String,
+      Right : HttpReturn
+    >
   };
 HttpPut :
   Type =
   {
-    put : (suffix : String) HttpReturn
+    put : (suffix : String) <
+      Left : String,
+      Right : HttpReturn
+    >
   };
 Reader :
   Type =
   {
-    read : () String
+    read : () <
+      Left : String,
+      Right : String
+    >
   };
 Writer :
   Type =
   {
-    write : (s : String) Unit
+    write : (s : String) <
+      Left : String,
+      Right : Unit
+    >
   };
 Either :
   (A : Type, B : Type) Type =

--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/Interpreter.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/backend/Interpreter.scala
@@ -285,8 +285,6 @@ class Interpreter(config : Config) {
                 "{" <> nest(line <> ssep(v1.map(toDocField), "," <> line)) <@> "}"
             case StrR(v1) =>
                 "\"" <> value(v1) <> "\""
-            case VarR(FldR(c, `uniR`)) =>
-                c.toLowerCase()
             case VarR(FldR(v1, v2)) =>
                 "<" <+> value(v1) <+> "=" <+> toDocRuntimeValue(v2) <+> ">"
             case VecR(elems) =>

--- a/src/test/resources/basic/oblivious.cooma
+++ b/src/test/resources/basic/oblivious.cooma
@@ -1,11 +1,11 @@
 {
-    // predef: val Reader = {read : () String}
-    type Reader2 = {read1 : () String, read2 : () String}
+    // predef: val Reader = {read : () <Left : String, Right : String>}
+    type Reader2 = {read1 : () <Left : String, Right : String>, read2 : () <Left : String, Right : String>}
     type Chooser = {choose : (Boolean) Reader}
 
     def alice () Reader2 = {
-        read1 = fun () "read1",
-        read2 = fun () "read2"
+        read1 = fun () <Right = "read1">,
+        read2 = fun () <Right = "read2">
     }
 
     def trusted () Chooser = {
@@ -20,8 +20,12 @@
         }
     }
 
-    def bob () String =
-        trusted().choose(false).read()
+    def bob () String = {
+        trusted().choose(false).read() match {
+            case Left(s) => s
+            case Right(s) => s
+        }
+    }
 
     bob()
 }

--- a/src/test/resources/capability/folderReaderCmdArg.cooma
+++ b/src/test/resources/capability/folderReaderCmdArg.cooma
@@ -1,5 +1,11 @@
 fun (reader: FolderReader) {
-    val a = reader.read("a.txt")
-    val b = reader.read("sub/b.txt")
+    val a = reader.read("a.txt") match {
+        case Left(s) => s
+        case Right(s) => s
+    }
+    val b = reader.read("sub/b.txt") match {
+        case Left(s) => s
+        case Right(s) => s
+    }
     Strings.concat(a, b)
 }

--- a/src/test/resources/capability/httpGetPostPut.cooma
+++ b/src/test/resources/capability/httpGetPostPut.cooma
@@ -1,7 +1,13 @@
 fun (httpClient : HttpGet & HttpPost & HttpPut) {
+    def getBody(response : <Left : String, Right : HttpReturn>) String = {
+        response match {
+            case Left(_) => ""
+            case Right(r) => r.body
+        }
+    }
     {
-        x0 = httpClient.get("").body,
-        x1 = httpClient.post("").body,
-        x2 = httpClient.put("").body
+        x0 = getBody(httpClient.get("")),
+        x1 = getBody(httpClient.post("")),
+        x2 = getBody(httpClient.put(""))
     }
 }

--- a/src/test/resources/capability/readerCmdArg.type
+++ b/src/test/resources/capability/readerCmdArg.type
@@ -1,1 +1,9 @@
-(r : { read : () String }) String
+(r : {
+  read : () <
+    Left : String,
+    Right : String
+  >
+}) <
+  Left : String,
+  Right : String
+>

--- a/src/test/resources/capability/readerCmdArg.usage
+++ b/src/test/resources/capability/readerCmdArg.usage
@@ -1,4 +1,4 @@
 arguments:
   r: a reader "source of data to read"
 result type:
-  String
+  < Left : String, Right : String >

--- a/src/test/resources/capability/readerWriterCmdArg.usage
+++ b/src/test/resources/capability/readerWriterCmdArg.usage
@@ -1,4 +1,4 @@
 arguments:
   rw: a reader, a writer
 result type:
-  String
+  < Left : String, Right : String >

--- a/src/test/resources/capability/writerAndReaderCmdArg.cooma
+++ b/src/test/resources/capability/writerAndReaderCmdArg.cooma
@@ -1,1 +1,13 @@
-fun (w : Writer, r : Reader) w.write(r.read())
+fun (w : Writer, r : Reader) {
+    type Result = <Left : String, Right : Unit>
+    r.read() match {
+        case Left(s) => {
+            val result : Result = <Left = s>
+            result
+        }
+        case Right(s) => {
+            val result : Result = w.write(s)
+            result
+        }
+    }
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/PrimitiveTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/PrimitiveTests.scala
@@ -11,6 +11,10 @@ import wolfendale.scalacheck.regexp.RegexpGen
 
 class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks with TryValues {
 
+    def toCoomaString(b : Boolean) =
+        if (b) "< True = {} >"
+        else "< False = {} >"
+
     // Primitive properties
 
     def testInt1Prim(op : UserPrimitive, f : BigInt => BigInt) : Unit =
@@ -23,7 +27,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
 
     def testIntRelPrim(op : UserPrimitive, f : (BigInt, BigInt) => Boolean) : Unit =
         super.test(s"run: prim ${primName(op)}")(implicit bc =>
-            forAll((l : BigInt, r : BigInt) => runPrimTest(s"prim ${primName(op)}", s"$l, $r", " : < False : Unit, True : Unit >", f(l, r).toString)))
+            forAll((l : BigInt, r : BigInt) => runPrimTest(s"prim ${primName(op)}", s"$l, $r", " : < False : Unit, True : Unit >", toCoomaString(f(l, r)))))
 
     testInt1Prim(IntAbsP(), _.abs)
     testInt2Prim(IntAddP(), _ + _)
@@ -87,7 +91,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
 
         test(s"run: Int prim $primName") { implicit bc =>
             forAll { (l : BigInt, r : BigInt) =>
-                runPrimTest(s"prim $primName", s"Int, $l, $r", " : < False : Unit, True : Unit >", (l == r).toString)
+                runPrimTest(s"prim $primName", s"Int, $l, $r", " : < False : Unit, True : Unit >", toCoomaString(l == r))
             }
         }
     }
@@ -117,7 +121,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
         test(s"run: String prim $primName") { implicit bc =>
             forAll(stringLit, stringLit) { (l : String, r : String) =>
                 whenever(isStringLit(l) && isStringLit(r)) {
-                    runPrimTest(s"prim $primName", s"""String, "$l", "$r"""", " : < False : Unit, True : Unit >", func(l, r).toString)
+                    runPrimTest(s"prim $primName", s"""String, "$l", "$r"""", " : < False : Unit, True : Unit >", toCoomaString(func(l, r)))
                 }
             }
         }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/ReplTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/ReplTests.scala
@@ -49,16 +49,25 @@ class ReplTests extends ExecutionTests {
                         fun (x : Boolean) x
                         res0(true)
                     """,
-        "res0 : (x : < False : Unit, True : Unit >) < False : Unit, True : Unit > = <function>\nres1 : < False : Unit, True : Unit > = true"
+        "res0 : (x : < False : Unit, True : Unit >) < False : Unit, True : Unit > = <function>\nres1 : < False : Unit, True : Unit > = < True = {} >"
     )
 
     test(
         "single evaluation (function using type alias that needs to be expanded)",
         """
                         fun (x : Reader) x.read()
-                        res0({read = fun () "hello"})
+                        res0({read = fun () <Right = "hello">})
                     """,
-        "res0 : (x : { read : () String }) String = <function>\nres1 : String = \"hello\""
+        """|res0 : (x : {
+           |  read : () <
+           |    Left : String,
+           |    Right : String
+           |  >
+           |}) <
+           |  Left : String,
+           |  Right : String
+           |> = <function>
+           |res1 : < Left : String, Right : String > = < Right = "hello" >""".stripMargin
     )
 
     test(
@@ -257,7 +266,7 @@ class ReplTests extends ExecutionTests {
            val b : MyBool = true
            b
         """,
-        "MyBool : Type = < False : Unit, True : Unit >\nb : MyBool = true\nb : < False : Unit, True : Unit > = true"
+        "MyBool : Type = < False : Unit, True : Unit >\nb : MyBool = < True = {} >\nb : < False : Unit, True : Unit > = < True = {} >"
     )
 
     test(
@@ -282,7 +291,7 @@ class ReplTests extends ExecutionTests {
     test(
         "user-defined type alias for prelude type (block)",
         "{ type MyBool = Boolean val b : MyBool = true b }",
-        "res0 : < False : Unit, True : Unit > = true"
+        "res0 : < False : Unit, True : Unit > = < True = {} >"
     )
 
     test(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/capability/FileIoTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/capability/FileIoTests.scala
@@ -15,7 +15,7 @@ class FileIoTests extends ExecutionTests {
         val name = s"reader external argument ($filename)"
         val reader = makeTempFilename(".txt")
         val content = "Contents to be read\n"
-        val expectedResult = "\"" + s"${Util.escape(content)}" + "\"" + "\n"
+        val expectedResult = "< Right = \"" + s"${Util.escape(content)}" + "\"" + " >\n"
         val args = Seq(reader)
 
         test(s"run: $name") { implicit bc =>
@@ -51,15 +51,15 @@ class FileIoTests extends ExecutionTests {
         test(s"run: $name: result") { implicit bc =>
             createFile(writer, "")
             val result = runFile(filename, Seq("-r"), args)
-            result shouldBe "{}\n"
+            result shouldBe "< Right = {} >\n"
             FileSource(writer).content shouldBe content
             deleteFile(writer)
         }
 
         test(s"run: $name: non-existent writer") { implicit bc =>
-            val writer = "notThere.txt"
-            val result = runFile(filename, Seq(), Seq(writer))
-            result shouldBe s"CapabilityException: WriterWrite: can't write $writer\n"
+            val writer = "notThere/a.txt"
+            val result = runFile(filename, Seq("-r"), Seq(writer))
+            result shouldBe "< Left = \"java.io.FileNotFoundException: notThere/a.txt (No such file or directory)\" >\n"
             Files.exists(Paths.get(writer)) shouldBe false
         }
 
@@ -149,7 +149,7 @@ class FileIoTests extends ExecutionTests {
             createFile(writer, "")
             createFile(reader, content)
             val result = runFile(filename, Seq("-r"), args)
-            result shouldBe "{}\n"
+            result shouldBe "< Right = {} >\n"
             FileSource(writer).content shouldBe content
             FileSource(reader).content shouldBe content
             deleteFile(writer)
@@ -158,9 +158,9 @@ class FileIoTests extends ExecutionTests {
 
         test(s"run: $name: non-existent writer") { implicit bc =>
             createFile(reader, "")
-            val writer = "notThere.txt"
-            val result = runFile(filename, Seq(), Seq(writer, reader))
-            result shouldBe s"CapabilityException: WriterWrite: can't write $writer\n"
+            val writer = "notThere/a.txt"
+            val result = runFile(filename, Seq("-r"), Seq(writer, reader))
+            result shouldBe "< Left = \"java.io.FileNotFoundException: notThere/a.txt (No such file or directory)\" >\n"
             Files.exists(Paths.get(writer)) shouldBe false
             deleteFile(writer)
         }
@@ -168,8 +168,8 @@ class FileIoTests extends ExecutionTests {
         test(s"run: $name: non-existent reader") { implicit bc =>
             createFile(writer, "")
             val reader = "notThere.txt"
-            val result = runFile(filename, Seq(), Seq(writer, reader))
-            result shouldBe s"CapabilityException: ReaderRead: can't read $reader\n"
+            val result = runFile(filename, Seq("-r"), Seq(writer, reader))
+            result shouldBe "< Left = \"java.io.FileNotFoundException: notThere.txt (No such file or directory)\" >\n"
             Files.exists(Paths.get(reader)) shouldBe false
             deleteFile(writer)
         }
@@ -204,7 +204,7 @@ class FileIoTests extends ExecutionTests {
         test(s"run: $name: result") { implicit bc =>
             createFile(rw, "The file contents\n")
             val result = runFile(filename, Seq("-r"), args)
-            result shouldBe "\"The file contents\\n\"\n"
+            result shouldBe "< Right = \"The file contents\\n\" >\n"
             FileSource(rw).content shouldBe "Hello, world!\n"
             deleteFile(rw)
         }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/capability/HttpClientTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/capability/HttpClientTests.scala
@@ -61,7 +61,7 @@ class HttpClientTests extends ExecutionTests {
 
         test(s"run: $name") { implicit bc =>
             val result = runFile(filename, Seq("-r"), args)
-            result shouldBe "{ code = 200, body = \"GET / response\" }\n"
+            result shouldBe "< Right = { code = 200, body = \"GET / response\" } >\n"
         }
     }
 
@@ -72,7 +72,7 @@ class HttpClientTests extends ExecutionTests {
 
         test(s"run: $name") { implicit bc =>
             val result = runFile(filename, Seq("-r"), args)
-            result shouldBe "{ code = 200, body = \"GET /foo response\" }\n"
+            result shouldBe "< Right = { code = 200, body = \"GET /foo response\" } >\n"
         }
     }
 
@@ -96,14 +96,20 @@ class HttpClientTests extends ExecutionTests {
             val result = runFile(filename, Seq("-r"), args)
             result shouldBe
                 """|src/test/resources/capability/httpNotPermitted.cooma:2:16:error: delete is not a field of record type {
-                   |  get : (suffix : String) {
-                   |    code : Int,
-                   |    body : String
-                   |  },
-                   |  put : (suffix : String) {
-                   |    code : Int,
-                   |    body : String
-                   |  }
+                   |  get : (suffix : String) <
+                   |    Left : String,
+                   |    Right : {
+                   |      code : Int,
+                   |      body : String
+                   |    }
+                   |  >,
+                   |  put : (suffix : String) <
+                   |    Left : String,
+                   |    Right : {
+                   |      code : Int,
+                   |      body : String
+                   |    }
+                   |  >
                    |}
                    |    httpClient.delete("")
                    |               ^

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
@@ -125,10 +125,10 @@ class FunctionTests extends ExpressionTests {
                 b = id(Boolean, true),
                 i = id(Int, 10),
                 s = id(String, "hello"),
-                r = id(Reader, { read = fun () "hello" })
+                r = id(Reader, { read = fun () < Right = "hello" > })
             }
         }""",
-        """{ b = true, i = 10, s = "hello", r = { read = <function> } }""",
+        """{ b = < True = {} >, i = 10, s = "hello", r = { read = <function> } }""",
         """|{
            |  b : <
            |    False : Unit,
@@ -137,7 +137,10 @@ class FunctionTests extends ExpressionTests {
            |  i : Int,
            |  s : String,
            |  r : {
-           |    read : () String
+           |    read : () <
+           |      Left : String,
+           |      Right : String
+           |    >
            |  }
            |}"""
     )

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/PredefTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/PredefTests.scala
@@ -8,7 +8,7 @@ class PredefTests extends ExpressionTests {
     test(
         "true",
         "true",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >",
         "true"
     )
@@ -16,7 +16,7 @@ class PredefTests extends ExpressionTests {
     test(
         "false",
         "false",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >",
         "false"
     )
@@ -24,70 +24,70 @@ class PredefTests extends ExpressionTests {
     test(
         "Booleans.and(false, false)",
         "Booleans.and(false, false)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.and(false, true)",
         "Booleans.and(false, true)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.and(true, false)",
         "Booleans.and(true, false)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.and(true, true)",
         "Booleans.and(true, true)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.not(false)",
         "Booleans.not(false)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.not(true)",
         "Booleans.not(true)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(false, false)",
         "Booleans.or(false, false)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(false, true)",
         "Booleans.or(false, true)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(true, false)",
         "Booleans.or(true, false)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(true, true)",
         "Booleans.or(true, true)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
@@ -274,112 +274,112 @@ class PredefTests extends ExpressionTests {
     test(
         "equality of integers (equal)",
         "equal(Int, 42, 42)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of integers (unequal)",
         "equal(Int, 42, 99)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of strings (equal)",
         s"""equal(String, "abc", "abc")""",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of strings (unequal)",
         s"""equal(String, "abc", "cba")""",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of Booleans (equal)",
         "equal(Boolean, true, true)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of Booleans (unequal)",
         "equal(Boolean, true, false)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (equal, flat)",
         "equal({x : Int, y : Int}, {x = 0, y = 1}, {y = 1, x = 0})",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (equal, nested)",
         "equal({x : { a : Int, b : Int }, y : Int}, {x = {a = 0, b = 0}, y = 1}, {y = 1, x = {b = 0, a = 0}})",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (unequal, flat",
         "equal({x : Int, y : Int}, {x = 0, y = 0}, {y = 1, x = 0})",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (unequal, nested)",
         "equal({x : { a : Int, b : Int }, y : Int}, {x = {a = 0, b = 0}, y = 1}, {y = 1, x = {b = 1, a = 0}})",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of Units (equal)",
         "equal(Unit, {}, {})",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (equal, flat)",
         "equal(< a : Int, v : String >, < a = 1 >, < a = 1 >)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (equal, nested)",
         "equal(< a : { x : Int, y : Int }, v : String >, < a = {x = 1, y = 2} >, < a = {y = 2, x = 1} >)",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (unequal, same constructor)",
         "equal(< a : Int, v : Int >, < a = 1 >, < a = 2 >)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (unequal, different constructor)",
         "equal(< a : Int, v : Int >, < a = 1 >, < v = 2 >)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (unequal, nested)",
         "equal(< a : { x : Int, y : Int }, v : String >, < a = {x = 1, y = 2} >, < a = {y = 2, x = 2} >)",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/VectorTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/VectorTests.scala
@@ -7,35 +7,35 @@ class VectorTests extends ExpressionTests {
     test(
         "equality of vectors (equal, nil)",
         "equal(Vector(), [], [])",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (equal, flat)",
         "equal(Vector(Int), [1, 2, 3], [1, 2, 3])",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (equal, nested)",
         "equal(Vector({a : Int}), [{a = 1}, {a = 2}], [{a = 1}, {a = 2}])",
-        "true",
+        "< True = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (unequal, flat)",
         "equal(Vector(Int), [1, 2, 3], [1, 2])",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (unequal, nested)",
         "equal(Vector({a : Int}), [{a = 1}, {a = 2}], [{a = 2}, {a = 2}])",
-        "false",
+        "< False = {} >",
         "< False : Unit, True : Unit >"
     )
 
@@ -87,7 +87,7 @@ class VectorTests extends ExpressionTests {
     test(
         "Boolean vector declaration",
         "[true, false]",
-        "[true, false]",
+        "[< True = {} >, < False = {} >]",
         "Vector(< False : Unit, True : Unit >)"
     )
 
@@ -97,7 +97,7 @@ class VectorTests extends ExpressionTests {
             Booleans.and(false, true),
             Booleans.and(true, false),
             Booleans.and(true, true)]""",
-        "[false, false, false, true]",
+        "[< False = {} >, < False = {} >, < False = {} >, < True = {} >]",
         "Vector(< False : Unit, True : Unit >)"
     )
 

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/BuiltInTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/BuiltInTests.scala
@@ -76,14 +76,14 @@ class BuiltInTests extends SemanticTests {
 
     test(
         "Reader read field has correct type",
-        "{ def f (r : Reader) String = r.read() 0 }",
+        "{ def f (r : Reader) <Left : String, Right : String> = r.read() 0 }",
         ""
     )
 
     test(
         "Reader doesn't have non-read field",
         "fun (r : Reader) r.foo",
-        """|1:20:error: foo is not a field of record type { read : () String }
+        """|1:20:error: foo is not a field of record type { read : () < Left : String, Right : String > }
            |fun (r : Reader) r.foo
            |                   ^
            |"""
@@ -97,14 +97,14 @@ class BuiltInTests extends SemanticTests {
 
     test(
         "Writer write field has correct type",
-        """{ def f (w : Writer) Unit = w.write("hi") 0 }""",
+        """{ def f (w : Writer) <Left : String, Right : Unit> = w.write("hi") 0 }""",
         ""
     )
 
     test(
         "Writer doesn't have non-write field",
         "fun (w : Writer) w.foo",
-        """|1:20:error: foo is not a field of record type { write : (s : String) Unit }
+        """|1:20:error: foo is not a field of record type { write : (s : String) < Left : String, Right : Unit > }
            |fun (w : Writer) w.foo
            |                   ^
            |"""
@@ -112,13 +112,13 @@ class BuiltInTests extends SemanticTests {
 
     test(
         "FolderReader has correct type",
-        """{ def f (r : FolderReader) String = r.read("a.txt") {} }""",
+        """{ def f (r : FolderReader) <Left : String, Right : String> = r.read("a.txt") {} }""",
         ""
     )
 
     test(
         "FolderWriter has correct type",
-        """{ def f (w : FolderWriter) Unit = w.write("a.txt", "text") {} }""",
+        """{ def f (w : FolderWriter) <Left : String, Right : Unit> = w.write("a.txt", "text") {} }""",
         ""
     )
 

--- a/truffle/src/main/java/org/bitbucket/inkytonik/cooma/truffle/runtime/VarRuntimeValue.java
+++ b/truffle/src/main/java/org/bitbucket/inkytonik/cooma/truffle/runtime/VarRuntimeValue.java
@@ -37,11 +37,7 @@ public class VarRuntimeValue extends RuntimeValue implements TruffleObject, Comp
 
     @Override
     public String toString() {
-        val vp = v.print();
-        if (vp.equals("{}"))
-            return c.toLowerCase();
-        else
-            return String.format("< %s = %s >", c, v.print());
+        return String.format("< %s = %s >", c, v.print());
     }
 
     @Override


### PR DESCRIPTION
This PR changes the behaviour of the reader, writer, and HTTP client capabilities. Instead of throwing Cooma exceptions for common IO errors, methods of these capabilities will return a variant representing whether the operation succeeded or failed.

The methods on each of these capabilities have been changed from `T` (where `T` is the old return type) to `< Left : String, Right : T >`. If an IO error occurs, the method will return the error `message` as `< Left = message >`. Otherwise, the `value` is returned as `< Right = value >`.

It is intended that the definition:

```
type Either = fun (A : Type, B : Type) < Left : A, Right : B >
```

…will be provided in the prelude once parameterised types are fully supported (see #45).