### PR TITLE
Type checking enhancements

### DIFF
--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Cooma.syntax
@@ -135,7 +135,7 @@ CaseTerm =
   '(' Identifier sp Identifier ')'.
 
 DefTerm =
-  \n Identifier sp Identifier sp Identifier sp '=' nestnl(Term).
+  \n "%def" Identifier sp Identifier sp Identifier sp '=' nestnl(Term).
 
 Value {line} =
     "%fun" Identifier sp Identifier sp '=' nestnl(Term)   {FunV}
@@ -192,9 +192,9 @@ StaticPrelude =
   Spacing StaticPreludeEntry* EOF.
 
 StaticPreludeEntry =
-    Identifier sp ':' nestnl(Expression) sp '=' nestnl(Expression) \n
+    Identifier sp ':' nestnl(Expression) sp '=' nestnl(Expression) ';' \n
       {StaticLetEntry}
-  | Identifier sp ':' nestnl(Expression) \n {StaticTypedEntry}.
+  | Identifier sp ':' nestnl(Expression) ';' \n {StaticTypedEntry}.
 
 DynamicPrelude =
   Spacing Term EOF.

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -97,7 +97,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
             analyser.tipe(program.expression) match {
                 case Some(tipe) =>
                     if (config.typePrint())
-                        config.output().emitln(show(analyser.alias(tipe)))
+                        config.output().emitln(show(tipe))
                     if (analyser.errors.isEmpty && config.usage())
                         printUsage(program.expression, tipe, config)
                 case None =>

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
@@ -141,7 +141,7 @@ trait REPL extends REPLBase[Config] {
         val tree = new Tree[ASTNode, REPLInput](input)
         val analyser = new SemanticAnalyser(tree, enter(currentStaticEnv))
         (analyser.errors, analyser.replTypeValue(input),
-            analyser.replType(input), analyser.aliasedReplType(input)) match {
+            analyser.replType(input), analyser.replType(input)) match {
                 case (Vector(), optTypeValue, replType, optAliasedReplType) =>
                     val input2 =
                         input match {
@@ -163,10 +163,6 @@ trait REPL extends REPLBase[Config] {
                                 defineLet(i, analyser.unalias(e, t), e)
                         }
                     Right((input2, optTypeValue, optAliasedReplType))
-
-                // case (Vector(), optTypeValue, replType, None) =>
-                //     // sys.error(s"checkInput: couldn't find aliased REPL type for $input")
-                //     Right((input, optTypeValue, ))
 
                 case (messages, _, _, _) =>
                     Left(messages)

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
@@ -584,10 +584,15 @@ class SemanticAnalyser(
         attr {
             case ArgumentEntity(n @ Argument(_, t, _)) =>
                 unalias(n, t)
-            case CaseValueEntity(tree.parent.pair(c, Mat(e, _))) =>
+            case CaseValueEntity(tree.parent.pair(Case(x, _, _), Mat(e, _))) =>
                 tipe(e) match {
-                    case Some(VarT(r)) if tree.index(c) - 1 < r.length =>
-                        Some(r(tree.index(c) - 1).expression)
+                    case Some(VarT(r)) =>
+                        r.find(_.identifier == x) match {
+                            case Some(field) =>
+                                unalias(e, field.expression)
+                            case None =>
+                                None
+                        }
                     case _ =>
                         None
                 }

--- a/prelude/prelude.cooma
+++ b/prelude/prelude.cooma
@@ -96,5 +96,11 @@
     write : (s : String) Unit
   }
 
+  // Useful type constructors
+
+  def Option (T : Type) Type = <None : Unit, Some : T>
+
+  def Either (A : Type, B : Type) Type = < Left : A, Right : B >
+
   {}
 }

--- a/prelude/prelude.cooma.dynamic
+++ b/prelude/prelude.cooma.dynamic
@@ -3,7 +3,7 @@
     %letc $k3 true =
       %letc $k4 Booleans =
         %letf
-          equal $k5 t =
+          %def equal $k5 t =
             %letv $f6 =
               %fun $k7 l =
                 %letv $f8 =
@@ -268,7 +268,7 @@
                 $k143 r
               %in %letc $k144 _ =
                 $k143 false
-              %in %case l (False $k144) (True $k145)
+              %in %case l (False $k144) (True $k145) 
           %in $k141 $f142
       %in %letv $f146 =
         %fun $k147 b =
@@ -276,7 +276,7 @@
             $k147 false
           %in %letc $k148 _ =
             $k147 true
-          %in %case b (False $k148) (True $k149)
+          %in %case b (False $k148) (True $k149) 
       %in %letv $f150 =
         %fun $k151 l =
           %letv $f152 =
@@ -285,7 +285,7 @@
                 $k153 true
               %in %letc $k154 _ =
                 $k153 r
-              %in %case l (False $k154) (True $k155)
+              %in %case l (False $k154) (True $k155) 
           %in $k151 $f152
       %in %letv $r139 =
         {

--- a/prelude/prelude.cooma.dynamic
+++ b/prelude/prelude.cooma.dynamic
@@ -25,292 +25,306 @@
                           %letc $k20 HttpPut =
                             %letc $k21 Reader =
                               %letc $k22 Writer =
-                                %letv $u23 =
+                                %letf
+                                  %def Option $k23 T =
+                                    %letv $u24 =
+                                      {
+                                      }
+                                    %in $k23 $u24
+                                  %def Either $k25 A =
+                                    %letv $f26 =
+                                      %fun $k27 B =
+                                        %letv $u28 =
+                                          {
+                                          }
+                                        %in $k27 $u28
+                                    %in $k25 $f26
+                                %in %letv $u29 =
                                   {
                                   }
-                                %in %halt $u23
-                              %in %letv $u24 =
+                                %in %halt $u29
+                              %in %letv $u30 =
                                 {
                                 }
-                              %in $k22 $u24
-                            %in %letv $u25 =
+                              %in $k22 $u30
+                            %in %letv $u31 =
                               {
                               }
-                            %in $k21 $u25
-                          %in %letv $u26 =
+                            %in $k21 $u31
+                          %in %letv $u32 =
                             {
                             }
-                          %in $k20 $u26
-                        %in %letv $u27 =
+                          %in $k20 $u32
+                        %in %letv $u33 =
                           {
                           }
-                        %in $k19 $u27
-                      %in %letv $u28 =
+                        %in $k19 $u33
+                      %in %letv $u34 =
                         {
                         }
-                      %in $k18 $u28
-                    %in %letv $u29 =
+                      %in $k18 $u34
+                    %in %letv $u35 =
                       {
                       }
-                    %in $k17 $u29
-                  %in %letv $u30 =
+                    %in $k17 $u35
+                  %in %letv $u36 =
                     {
                     }
-                  %in $k16 $u30
-                %in %letv $u31 =
+                  %in $k16 $u36
+                %in %letv $u37 =
                   {
                   }
-                %in $k15 $u31
-              %in %letv $u32 =
+                %in $k15 $u37
+              %in %letv $u38 =
                 {
                 }
-              %in $k14 $u32
-            %in %letv $f34 =
-              %fun $k35 t =
-                %letv $f36 =
-                  %fun $k37 v =
-                    %letv $f38 =
-                      %fun $k39 e =
-                        %letv $r40 =
+              %in $k14 $u38
+            %in %letv $f40 =
+              %fun $k41 t =
+                %letv $f42 =
+                  %fun $k43 v =
+                    %letv $f44 =
+                      %fun $k45 e =
+                        %letv $r46 =
                           %prim VecAppend t v e
-                        %in $k39 $r40
-                    %in $k37 $f38
-                %in $k35 $f36
-            %in %letv $f41 =
-              %fun $k42 t =
-                %letv $f43 =
-                  %fun $k44 l =
-                    %letv $f45 =
-                      %fun $k46 r =
-                        %letv $r47 =
+                        %in $k45 $r46
+                    %in $k43 $f44
+                %in $k41 $f42
+            %in %letv $f47 =
+              %fun $k48 t =
+                %letv $f49 =
+                  %fun $k50 l =
+                    %letv $f51 =
+                      %fun $k52 r =
+                        %letv $r53 =
                           %prim VecConcat t l r
-                        %in $k46 $r47
-                    %in $k44 $f45
-                %in $k42 $f43
-            %in %letv $f48 =
-              %fun $k49 t =
-                %letv $f50 =
-                  %fun $k51 v =
-                    %letv $f52 =
-                      %fun $k53 i =
-                        %letv $r54 =
+                        %in $k52 $r53
+                    %in $k50 $f51
+                %in $k48 $f49
+            %in %letv $f54 =
+              %fun $k55 t =
+                %letv $f56 =
+                  %fun $k57 v =
+                    %letv $f58 =
+                      %fun $k59 i =
+                        %letv $r60 =
                           %prim VecGet t v i
-                        %in $k53 $r54
-                    %in $k51 $f52
-                %in $k49 $f50
-            %in %letv $f55 =
-              %fun $k56 t =
-                %letv $f57 =
-                  %fun $k58 v =
-                    %letv $r59 =
+                        %in $k59 $r60
+                    %in $k57 $f58
+                %in $k55 $f56
+            %in %letv $f61 =
+              %fun $k62 t =
+                %letv $f63 =
+                  %fun $k64 v =
+                    %letv $r65 =
                       %prim VecLength t v
-                    %in $k58 $r59
-                %in $k56 $f57
-            %in %letv $f60 =
-              %fun $k61 t =
-                %letv $f62 =
-                  %fun $k63 v =
-                    %letv $f64 =
-                      %fun $k65 e =
-                        %letv $r66 =
+                    %in $k64 $r65
+                %in $k62 $f63
+            %in %letv $f66 =
+              %fun $k67 t =
+                %letv $f68 =
+                  %fun $k69 v =
+                    %letv $f70 =
+                      %fun $k71 e =
+                        %letv $r72 =
                           %prim VecPrepend t v e
-                        %in $k65 $r66
-                    %in $k63 $f64
-                %in $k61 $f62
-            %in %letv $f67 =
-              %fun $k68 t =
-                %letv $f69 =
-                  %fun $k70 v =
-                    %letv $f71 =
-                      %fun $k72 i =
-                        %letv $f73 =
-                          %fun $k74 e =
-                            %letv $r75 =
+                        %in $k71 $r72
+                    %in $k69 $f70
+                %in $k67 $f68
+            %in %letv $f73 =
+              %fun $k74 t =
+                %letv $f75 =
+                  %fun $k76 v =
+                    %letv $f77 =
+                      %fun $k78 i =
+                        %letv $f79 =
+                          %fun $k80 e =
+                            %letv $r81 =
                               %prim VecPut t v i e
-                            %in $k74 $r75
-                        %in $k72 $f73
-                    %in $k70 $f71
-                %in $k68 $f69
-            %in %letv $r33 =
+                            %in $k80 $r81
+                        %in $k78 $f79
+                    %in $k76 $f77
+                %in $k74 $f75
+            %in %letv $r39 =
               {
-                append = $f34
-                concat = $f41
-                get = $f48
-                length = $f55
-                prepend = $f60
-                put = $f67
+                append = $f40
+                concat = $f47
+                get = $f54
+                length = $f61
+                prepend = $f66
+                put = $f73
               }
-            %in $k13 $r33
-          %in %letv $f77 =
-            %fun $k78 l =
-              %letv $f79 =
-                %fun $k80 r =
-                  %letv $r81 =
+            %in $k13 $r39
+          %in %letv $f83 =
+            %fun $k84 l =
+              %letv $f85 =
+                %fun $k86 r =
+                  %letv $r87 =
                     %prim StrConcat l r
-                  %in $k80 $r81
-              %in $k78 $f79
-          %in %letv $f82 =
-            %fun $k83 s =
-              %letv $r84 =
+                  %in $k86 $r87
+              %in $k84 $f85
+          %in %letv $f88 =
+            %fun $k89 s =
+              %letv $r90 =
                 %prim StrLength s
-              %in $k83 $r84
-          %in %letv $f85 =
-            %fun $k86 s =
-              %letv $f87 =
-                %fun $k88 i =
-                  %letv $r89 =
+              %in $k89 $r90
+          %in %letv $f91 =
+            %fun $k92 s =
+              %letv $f93 =
+                %fun $k94 i =
+                  %letv $r95 =
                     %prim StrSubstr s i
-                  %in $k88 $r89
-              %in $k86 $f87
-          %in %letv $r76 =
+                  %in $k94 $r95
+              %in $k92 $f93
+          %in %letv $r82 =
             {
-              concat = $f77
-              length = $f82
-              substr = $f85
+              concat = $f83
+              length = $f88
+              substr = $f91
             }
-          %in $k12 $r76
-        %in %letv $f91 =
-          %fun $k92 i =
-            %letv $r93 =
+          %in $k12 $r82
+        %in %letv $f97 =
+          %fun $k98 i =
+            %letv $r99 =
               %prim IntAbs i
-            %in $k92 $r93
-        %in %letv $f94 =
-          %fun $k95 l =
-            %letv $f96 =
-              %fun $k97 r =
-                %letv $r98 =
+            %in $k98 $r99
+        %in %letv $f100 =
+          %fun $k101 l =
+            %letv $f102 =
+              %fun $k103 r =
+                %letv $r104 =
                   %prim IntAdd l r
-                %in $k97 $r98
-            %in $k95 $f96
-        %in %letv $f99 =
-          %fun $k100 l =
-            %letv $f101 =
-              %fun $k102 r =
-                %letv $r103 =
+                %in $k103 $r104
+            %in $k101 $f102
+        %in %letv $f105 =
+          %fun $k106 l =
+            %letv $f107 =
+              %fun $k108 r =
+                %letv $r109 =
                   %prim IntDiv l r
-                %in $k102 $r103
-            %in $k100 $f101
-        %in %letv $f104 =
-          %fun $k105 l =
-            %letv $f106 =
-              %fun $k107 r =
-                %letv $r108 =
+                %in $k108 $r109
+            %in $k106 $f107
+        %in %letv $f110 =
+          %fun $k111 l =
+            %letv $f112 =
+              %fun $k113 r =
+                %letv $r114 =
                   %prim IntMul l r
-                %in $k107 $r108
-            %in $k105 $f106
-        %in %letv $f109 =
-          %fun $k110 l =
-            %letv $f111 =
-              %fun $k112 r =
-                %letv $r113 =
+                %in $k113 $r114
+            %in $k111 $f112
+        %in %letv $f115 =
+          %fun $k116 l =
+            %letv $f117 =
+              %fun $k118 r =
+                %letv $r119 =
                   %prim IntPow l r
-                %in $k112 $r113
-            %in $k110 $f111
-        %in %letv $f114 =
-          %fun $k115 l =
-            %letv $f116 =
-              %fun $k117 r =
-                %letv $r118 =
+                %in $k118 $r119
+            %in $k116 $f117
+        %in %letv $f120 =
+          %fun $k121 l =
+            %letv $f122 =
+              %fun $k123 r =
+                %letv $r124 =
                   %prim IntSub l r
-                %in $k117 $r118
-            %in $k115 $f116
-        %in %letv $f119 =
-          %fun $k120 l =
-            %letv $f121 =
-              %fun $k122 r =
-                %letv $r123 =
+                %in $k123 $r124
+            %in $k121 $f122
+        %in %letv $f125 =
+          %fun $k126 l =
+            %letv $f127 =
+              %fun $k128 r =
+                %letv $r129 =
                   %prim IntLt l r
-                %in $k122 $r123
-            %in $k120 $f121
-        %in %letv $f124 =
-          %fun $k125 l =
-            %letv $f126 =
-              %fun $k127 r =
-                %letv $r128 =
+                %in $k128 $r129
+            %in $k126 $f127
+        %in %letv $f130 =
+          %fun $k131 l =
+            %letv $f132 =
+              %fun $k133 r =
+                %letv $r134 =
                   %prim IntLte l r
-                %in $k127 $r128
-            %in $k125 $f126
-        %in %letv $f129 =
-          %fun $k130 l =
-            %letv $f131 =
-              %fun $k132 r =
-                %letv $r133 =
+                %in $k133 $r134
+            %in $k131 $f132
+        %in %letv $f135 =
+          %fun $k136 l =
+            %letv $f137 =
+              %fun $k138 r =
+                %letv $r139 =
                   %prim IntGt l r
-                %in $k132 $r133
-            %in $k130 $f131
-        %in %letv $f134 =
-          %fun $k135 l =
-            %letv $f136 =
-              %fun $k137 r =
-                %letv $r138 =
+                %in $k138 $r139
+            %in $k136 $f137
+        %in %letv $f140 =
+          %fun $k141 l =
+            %letv $f142 =
+              %fun $k143 r =
+                %letv $r144 =
                   %prim IntGte l r
-                %in $k137 $r138
-            %in $k135 $f136
-        %in %letv $r90 =
+                %in $k143 $r144
+            %in $k141 $f142
+        %in %letv $r96 =
           {
-            abs = $f91
-            add = $f94
-            div = $f99
-            mul = $f104
-            pow = $f109
-            sub = $f114
-            lt = $f119
-            lte = $f124
-            gt = $f129
-            gte = $f134
+            abs = $f97
+            add = $f100
+            div = $f105
+            mul = $f110
+            pow = $f115
+            sub = $f120
+            lt = $f125
+            lte = $f130
+            gt = $f135
+            gte = $f140
           }
-        %in $k11 $r90
-      %in %letv $f140 =
-        %fun $k141 l =
-          %letv $f142 =
-            %fun $k143 r =
-              %letc $k145 _ =
-                $k143 r
-              %in %letc $k144 _ =
-                $k143 false
-              %in %case l (False $k144) (True $k145) 
-          %in $k141 $f142
+        %in $k11 $r96
       %in %letv $f146 =
-        %fun $k147 b =
-          %letc $k149 _ =
-            $k147 false
-          %in %letc $k148 _ =
-            $k147 true
-          %in %case b (False $k148) (True $k149) 
-      %in %letv $f150 =
-        %fun $k151 l =
-          %letv $f152 =
-            %fun $k153 r =
-              %letc $k155 _ =
-                $k153 true
-              %in %letc $k154 _ =
-                $k153 r
-              %in %case l (False $k154) (True $k155) 
-          %in $k151 $f152
-      %in %letv $r139 =
+        %fun $k147 l =
+          %letv $f148 =
+            %fun $k149 r =
+              %letc $k151 _ =
+                $k149 r
+              %in %letc $k150 _ =
+                $k149 false
+              %in %case l (False $k150) (True $k151) 
+          %in $k147 $f148
+      %in %letv $f152 =
+        %fun $k153 b =
+          %letc $k155 _ =
+            $k153 false
+          %in %letc $k154 _ =
+            $k153 true
+          %in %case b (False $k154) (True $k155) 
+      %in %letv $f156 =
+        %fun $k157 l =
+          %letv $f158 =
+            %fun $k159 r =
+              %letc $k161 _ =
+                $k159 true
+              %in %letc $k160 _ =
+                $k159 r
+              %in %case l (False $k160) (True $k161) 
+          %in $k157 $f158
+      %in %letv $r145 =
         {
-          and = $f140
-          not = $f146
-          or = $f150
+          and = $f146
+          not = $f152
+          or = $f156
         }
-      %in $k4 $r139
-    %in %letv $u157 =
+      %in $k4 $r145
+    %in %letv $u163 =
       {
       }
-    %in %letv $r156 =
+    %in %letv $r162 =
       <
-        True = $u157
+        True = $u163
       >
-    %in $k3 $r156
-  %in %letv $u159 =
+    %in $k3 $r162
+  %in %letv $u165 =
     {
     }
-  %in %letv $r158 =
+  %in %letv $r164 =
     <
-      False = $u159
+      False = $u165
     >
-  %in $k2 $r158
-%in %letv $u160 =
+  %in $k2 $r164
+%in %letv $u166 =
   {
   }
-%in $k1 $u160
+%in $k1 $u166

--- a/prelude/prelude.cooma.static
+++ b/prelude/prelude.cooma.static
@@ -135,3 +135,15 @@ Writer :
   {
     write : (s : String) Unit
   };
+Either :
+  (A : Type, B : Type) Type =
+  fun (A : Type, B : Type) <
+    Left : A,
+    Right : B
+  >;
+Option :
+  (T : Type) Type =
+  fun (T : Type) <
+    None : Unit,
+    Some : T
+  >;

--- a/prelude/prelude.cooma.static
+++ b/prelude/prelude.cooma.static
@@ -1,23 +1,20 @@
-Boolean : 
+Boolean :
   Type =
   <
     False : Unit,
     True : Unit
-  >
-
-false : 
+  >;
+false :
   <
     False : Unit,
     True : Unit
-  >
-
-true : 
+  >;
+true :
   <
     False : Unit,
     True : Unit
-  >
-
-Booleans : 
+  >;
+Booleans :
   {
     and : (l : <
       False : Unit,
@@ -46,15 +43,13 @@ Booleans :
       False : Unit,
       True : Unit
     >
-  }
-
-equal : 
+  };
+equal :
   (t : Type, l : t, r : t) <
     False : Unit,
     True : Unit
-  >
-
-Ints : 
+  >;
+Ints :
   {
     abs : (i : Int) Int,
     add : (l : Int, r : Int) Int,
@@ -78,16 +73,14 @@ Ints :
       False : Unit,
       True : Unit
     >
-  }
-
-Strings : 
+  };
+Strings :
   {
     concat : (l : String, r : String) String,
     length : (s : String) Int,
     substr : (s : String, i : Int) String
-  }
-
-Vectors : 
+  };
+Vectors :
   {
     append : (t : Type, v : Vector(t), e : t) Vector(t),
     concat : (t : Type, l : Vector(t), r : Vector(t)) Vector(t),
@@ -95,60 +88,50 @@ Vectors :
     length : (t : Type, v : Vector(t)) Int,
     prepend : (t : Type, v : Vector(t), e : t) Vector(t),
     put : (t : Type, v : Vector(t), i : Int, e : t) Vector(t)
-  }
-
-FolderReader : 
+  };
+FolderReader :
   Type =
   {
     read : (suffix : String) String
-  }
-
-FolderWriter : 
+  };
+FolderWriter :
   Type =
   {
     write : (suffix : String, s : String) Unit
-  }
-
-HttpReturn : 
+  };
+HttpReturn :
   Type =
   {
     code : Int,
     body : String
-  }
-
-HttpDelete : 
+  };
+HttpDelete :
   Type =
   {
     delete : (suffix : String) HttpReturn
-  }
-
-HttpGet : 
+  };
+HttpGet :
   Type =
   {
     get : (suffix : String) HttpReturn
-  }
-
-HttpPost : 
+  };
+HttpPost :
   Type =
   {
     post : (suffix : String) HttpReturn
-  }
-
-HttpPut : 
+  };
+HttpPut :
   Type =
   {
     put : (suffix : String) HttpReturn
-  }
-
-Reader : 
+  };
+Reader :
   Type =
   {
     read : () String
-  }
-
-Writer : 
+  };
+Writer :
   Type =
   {
     write : (s : String) Unit
-  }
-
+  };

--- a/src/test/resources/basic/blockDef.IR
+++ b/src/test/resources/basic/blockDef.IR
@@ -1,7 +1,7 @@
 %letf
-  f $k1 x =
+  %def f $k1 x =
     $k1 x
-  g $k2 y =
+  %def g $k2 y =
     f $k2 y
 %in %letv $i5 =
   10

--- a/src/test/resources/prelude/ok-prelude.cooma.dynamic.out
+++ b/src/test/resources/prelude/ok-prelude.cooma.dynamic.out
@@ -1,6 +1,6 @@
 %letc $k1 Foo =
   %letf
-    add $k2 l =
+    %def add $k2 l =
       %letv $f3 =
         %fun $k4 r =
           %letv $r5 =

--- a/src/test/resources/prelude/ok-prelude.cooma.static.out
+++ b/src/test/resources/prelude/ok-prelude.cooma.static.out
@@ -1,10 +1,10 @@
 Foo :
   Type =
-  Int
+  Int;
 add :
-  (l : Int, r : Int) Int
+  (l : Int, r : Int) Int;
 sub :
-  (l : Int, r : Int) Int
+  (l : Int, r : Int) Int;
 x :
   {
     a : Int,
@@ -13,4 +13,4 @@ x :
     d : <
       e : Int
     >
-  }
+  };

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/PrimitiveTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/PrimitiveTests.scala
@@ -23,7 +23,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
 
     def testIntRelPrim(op : UserPrimitive, f : (BigInt, BigInt) => Boolean) : Unit =
         super.test(s"run: prim ${primName(op)}")(implicit bc =>
-            forAll((l : BigInt, r : BigInt) => runPrimTest(s"prim ${primName(op)}", s"$l, $r", " : Boolean", f(l, r).toString)))
+            forAll((l : BigInt, r : BigInt) => runPrimTest(s"prim ${primName(op)}", s"$l, $r", " : < False : Unit, True : Unit >", f(l, r).toString)))
 
     testInt1Prim(IntAbsP(), _.abs)
     testInt2Prim(IntAddP(), _ + _)
@@ -87,7 +87,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
 
         test(s"run: Int prim $primName") { implicit bc =>
             forAll { (l : BigInt, r : BigInt) =>
-                runPrimTest(s"prim $primName", s"Int, $l, $r", " : Boolean", (l == r).toString)
+                runPrimTest(s"prim $primName", s"Int, $l, $r", " : < False : Unit, True : Unit >", (l == r).toString)
             }
         }
     }
@@ -117,7 +117,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
         test(s"run: String prim $primName") { implicit bc =>
             forAll(stringLit, stringLit) { (l : String, r : String) =>
                 whenever(isStringLit(l) && isStringLit(r)) {
-                    runPrimTest(s"prim $primName", s"""String, "$l", "$r"""", " : Boolean", func(l, r).toString)
+                    runPrimTest(s"prim $primName", s"""String, "$l", "$r"""", " : < False : Unit, True : Unit >", func(l, r).toString)
                 }
             }
         }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/PrimitiveTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/PrimitiveTests.scala
@@ -203,7 +203,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
             forAll { (v : Vector[Int], i : Int) =>
                 val arg2 = vecToLiteral(v)
                 val result = vecToLiteral(func(v, i))
-                runPrimTest(s"prim $primName", s"Int, $arg2, $i", "", result)
+                runPrimTest(s"prim $primName", s"Int, $arg2, $i", " : Vector(Int)", result)
             }
         }
     }
@@ -217,7 +217,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
                 val arg2 = vecToLiteral(v1)
                 val arg3 = vecToLiteral(v2)
                 val result = vecToLiteral(func(v1, v2))
-                runPrimTest(s"prim $primName", s"Int, $arg2, $arg3", "", result)
+                runPrimTest(s"prim $primName", s"Int, $arg2, $arg3", " : Vector(Int)", result)
             }
         }
     }
@@ -242,7 +242,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
                         forAll(indexesOf(v)) { (i : Int) =>
                             whenever((i >= 0) && (i < v.length)) {
                                 val arg2 = vecToLiteral(v)
-                                runPrimTest(s"prim $primName", s"Int, $arg2, $i", "", s"${func(v, i)}")
+                                runPrimTest(s"prim $primName", s"Int, $arg2, $i", " : Int", s"${func(v, i)}")
                             }
                         }
                     }
@@ -274,7 +274,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
                                 forAll { (e : Int) =>
                                     val arg2 = vecToLiteral(v)
                                     val result = vecToLiteral(func(v, i, e))
-                                    runPrimTest(s"prim $primName", s"Int, $arg2, $i, $e", "", result)
+                                    runPrimTest(s"prim $primName", s"Int, $arg2, $i, $e", " : Vector(Int)", result)
                                 }
                             }
                         }
@@ -318,7 +318,7 @@ class PrimitiveTests extends ExecutionTests with ScalaCheckDrivenPropertyChecks 
             forAll { (v : Vector[Int], i : Int) =>
                 val arg2 = vecToLiteral(v)
                 val result = vecToLiteral(func(v, i))
-                runPrimTest(s"prim $primName", s"Int, $arg2, $i", "", result)
+                runPrimTest(s"prim $primName", s"Int, $arg2, $i", " : Vector(Int)", result)
             }
         }
     }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/ReplTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/ReplTests.scala
@@ -49,7 +49,7 @@ class ReplTests extends ExecutionTests {
                         fun (x : Boolean) x
                         res0(true)
                     """,
-        "res0 : (x : Boolean) Boolean = <function>\nres1 : Boolean = true"
+        "res0 : (x : < False : Unit, True : Unit >) < False : Unit, True : Unit > = <function>\nres1 : < False : Unit, True : Unit > = true"
     )
 
     test(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
@@ -149,4 +149,68 @@ class FunctionTests extends ExpressionTests {
         "String"
     )
 
+    test(
+        "type application in type (def)",
+        """{
+             def MyOption(T : Type) Type = <None : Unit, Some : T>
+             val x : MyOption(Int) = <Some = 3>
+             x
+        }""",
+        "< Some = 3 >",
+        "< None : Unit, Some : Int >"
+    )
+
+    test(
+        "type application in type (val fun, single arg)",
+        """{
+             val MyOption = fun (T : Type) <None : Unit, Some : T>
+             val x : MyOption(Int) = <Some = 3>
+             x
+        }""",
+        "< Some = 3 >",
+        "< None : Unit, Some : Int >"
+    )
+
+    test(
+        "type application in type (type fun, single arg))",
+        """{
+             type MyOption = fun (T : Type) <None : Unit, Some : T>
+             val x : MyOption(Int) = <Some = 3>
+             x
+        }""",
+        "< Some = 3 >",
+        "< None : Unit, Some : Int >"
+    )
+
+    test(
+        "type application in type (prelude, single arg))",
+        """{
+             val x : Option(Int) = <Some = 3>
+             x
+        }""",
+        "< Some = 3 >",
+        "< None : Unit, Some : Int >"
+    )
+
+    test(
+        "type application in type (multiple args)",
+        """{
+             type MyEither = fun (A : Type, B : Type) < Left : A, Right : B >
+             val x : MyEither(Int, String) = <Left = 42>
+             x
+        }""",
+        "< Left = 42 >",
+        "< Left : Int, Right : String >"
+    )
+
+    test(
+        "type application in type (prelude, multiple args)",
+        """{
+             val x : Either(Int, String) = <Right = "hi">
+             x
+        }""",
+        """< Right = "hi" >""",
+        "< Left : Int, Right : String >"
+    )
+
 }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
@@ -129,7 +129,17 @@ class FunctionTests extends ExpressionTests {
             }
         }""",
         """{ b = true, i = 10, s = "hello", r = { read = <function> } }""",
-        "{ b : Boolean, i : Int, s : String, r : { read : () String } }"
+        """|{
+           |  b : <
+           |    False : Unit,
+           |    True : Unit
+           |  >,
+           |  i : Int,
+           |  s : String,
+           |  r : {
+           |    read : () String
+           |  }
+           |}"""
     )
 
     test(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/PredefTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/PredefTests.scala
@@ -9,7 +9,7 @@ class PredefTests extends ExpressionTests {
         "true",
         "true",
         "true",
-        "Boolean",
+        "< False : Unit, True : Unit >",
         "true"
     )
 
@@ -17,7 +17,7 @@ class PredefTests extends ExpressionTests {
         "false",
         "false",
         "false",
-        "Boolean",
+        "< False : Unit, True : Unit >",
         "false"
     )
 
@@ -25,70 +25,70 @@ class PredefTests extends ExpressionTests {
         "Booleans.and(false, false)",
         "Booleans.and(false, false)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.and(false, true)",
         "Booleans.and(false, true)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.and(true, false)",
         "Booleans.and(true, false)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.and(true, true)",
         "Booleans.and(true, true)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.not(false)",
         "Booleans.not(false)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.not(true)",
         "Booleans.not(true)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(false, false)",
         "Booleans.or(false, false)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(false, true)",
         "Booleans.or(false, true)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(true, false)",
         "Booleans.or(true, false)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "Booleans.or(true, true)",
         "Booleans.or(true, true)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
@@ -96,9 +96,33 @@ class PredefTests extends ExpressionTests {
         "Booleans",
         "{ and = <function>, not = <function>, or = <function> }",
         """{
-          |  and : (l : Boolean, r : Boolean) Boolean,
-          |  not : (b : Boolean) Boolean,
-          |  or : (l : Boolean, r : Boolean) Boolean
+          |  and : (l : <
+          |    False : Unit,
+          |    True : Unit
+          |  >, r : <
+          |    False : Unit,
+          |    True : Unit
+          |  >) <
+          |    False : Unit,
+          |    True : Unit
+          |  >,
+          |  not : (b : <
+          |    False : Unit,
+          |    True : Unit
+          |  >) <
+          |    False : Unit,
+          |    True : Unit
+          |  >,
+          |  or : (l : <
+          |    False : Unit,
+          |    True : Unit
+          |  >, r : <
+          |    False : Unit,
+          |    True : Unit
+          |  >) <
+          |    False : Unit,
+          |    True : Unit
+          |  >
           |}""",
         "Booleans"
     )
@@ -125,10 +149,22 @@ class PredefTests extends ExpressionTests {
           |  mul : (l : Int, r : Int) Int,
           |  pow : (l : Int, r : Int) Int,
           |  sub : (l : Int, r : Int) Int,
-          |  lt : (l : Int, r : Int) Boolean,
-          |  lte : (l : Int, r : Int) Boolean,
-          |  gt : (l : Int, r : Int) Boolean,
-          |  gte : (l : Int, r : Int) Boolean
+          |  lt : (l : Int, r : Int) <
+          |    False : Unit,
+          |    True : Unit
+          |  >,
+          |  lte : (l : Int, r : Int) <
+          |    False : Unit,
+          |    True : Unit
+          |  >,
+          |  gt : (l : Int, r : Int) <
+          |    False : Unit,
+          |    True : Unit
+          |  >,
+          |  gte : (l : Int, r : Int) <
+          |    False : Unit,
+          |    True : Unit
+          |  >
           |}""",
         "Ints"
     )
@@ -156,10 +192,22 @@ class PredefTests extends ExpressionTests {
           |    mul : (l : Int, r : Int) Int,
           |    pow : (l : Int, r : Int) Int,
           |    sub : (l : Int, r : Int) Int,
-          |    lt : (l : Int, r : Int) Boolean,
-          |    lte : (l : Int, r : Int) Boolean,
-          |    gt : (l : Int, r : Int) Boolean,
-          |    gte : (l : Int, r : Int) Boolean
+          |    lt : (l : Int, r : Int) <
+          |      False : Unit,
+          |      True : Unit
+          |    >,
+          |    lte : (l : Int, r : Int) <
+          |      False : Unit,
+          |      True : Unit
+          |    >,
+          |    gt : (l : Int, r : Int) <
+          |      False : Unit,
+          |      True : Unit
+          |    >,
+          |    gte : (l : Int, r : Int) <
+          |      False : Unit,
+          |      True : Unit
+          |    >
           |  }
           |>"""
     )
@@ -194,10 +242,22 @@ class PredefTests extends ExpressionTests {
           |      mul : (l : Int, r : Int) Int,
           |      pow : (l : Int, r : Int) Int,
           |      sub : (l : Int, r : Int) Int,
-          |      lt : (l : Int, r : Int) Boolean,
-          |      lte : (l : Int, r : Int) Boolean,
-          |      gt : (l : Int, r : Int) Boolean,
-          |      gte : (l : Int, r : Int) Boolean
+          |      lt : (l : Int, r : Int) <
+          |        False : Unit,
+          |        True : Unit
+          |      >,
+          |      lte : (l : Int, r : Int) <
+          |        False : Unit,
+          |        True : Unit
+          |      >,
+          |      gt : (l : Int, r : Int) <
+          |        False : Unit,
+          |        True : Unit
+          |      >,
+          |      gte : (l : Int, r : Int) <
+          |        False : Unit,
+          |        True : Unit
+          |      >
           |    }
           |  }
           |}"""
@@ -207,7 +267,7 @@ class PredefTests extends ExpressionTests {
         "equal has the correct type",
         "equal",
         "<function>",
-        "(t : Type, l : t, r : t) Boolean",
+        "(t : Type, l : t, r : t) < False : Unit, True : Unit >",
         "equal"
     )
 
@@ -215,112 +275,112 @@ class PredefTests extends ExpressionTests {
         "equality of integers (equal)",
         "equal(Int, 42, 42)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of integers (unequal)",
         "equal(Int, 42, 99)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of strings (equal)",
         s"""equal(String, "abc", "abc")""",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of strings (unequal)",
         s"""equal(String, "abc", "cba")""",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of Booleans (equal)",
         "equal(Boolean, true, true)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of Booleans (unequal)",
         "equal(Boolean, true, false)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (equal, flat)",
         "equal({x : Int, y : Int}, {x = 0, y = 1}, {y = 1, x = 0})",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (equal, nested)",
         "equal({x : { a : Int, b : Int }, y : Int}, {x = {a = 0, b = 0}, y = 1}, {y = 1, x = {b = 0, a = 0}})",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (unequal, flat",
         "equal({x : Int, y : Int}, {x = 0, y = 0}, {y = 1, x = 0})",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of records (unequal, nested)",
         "equal({x : { a : Int, b : Int }, y : Int}, {x = {a = 0, b = 0}, y = 1}, {y = 1, x = {b = 1, a = 0}})",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of Units (equal)",
         "equal(Unit, {}, {})",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (equal, flat)",
         "equal(< a : Int, v : String >, < a = 1 >, < a = 1 >)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (equal, nested)",
         "equal(< a : { x : Int, y : Int }, v : String >, < a = {x = 1, y = 2} >, < a = {y = 2, x = 1} >)",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (unequal, same constructor)",
         "equal(< a : Int, v : Int >, < a = 1 >, < a = 2 >)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (unequal, different constructor)",
         "equal(< a : Int, v : Int >, < a = 1 >, < v = 2 >)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of variants (unequal, nested)",
         "equal(< a : { x : Int, y : Int }, v : String >, < a = {x = 1, y = 2} >, < a = {y = 2, x = 2} >)",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
@@ -386,13 +446,13 @@ class PredefTests extends ExpressionTests {
             s"pre-defined Ints.${primFunName(op)} has the correct type",
             s"Ints.${primFunName(op)}",
             "<function>",
-            "(l : Int, r : Int) Boolean"
+            "(l : Int, r : Int) < False : Unit, True : Unit >"
         )
         test(
             s"pre-defined Ints.${primFunName(op)} partial application has the correct type",
             s"Ints.${primFunName(op)}(1)",
             "<function>",
-            "(r : Int) Boolean"
+            "(r : Int) < False : Unit, True : Unit >"
         )
     }
 

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/VariantTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/VariantTests.scala
@@ -74,10 +74,50 @@ class VariantTests extends ExpressionTests {
     test(
         "multi-case match (later case, different order)",
         """{
-            def f () < x : Int, y : Int > = < x = 3>
+            def f () < x : Int, y : Int > = < x = 3 >
             f () match { case y(b) => 1 case x(a) => 2 }
         }""",
         "2",
+        "Int"
+    )
+
+    test(
+        "multi-case match (different bound var types, same order, first case)",
+        """{
+            def f () < x : Int, y : String > = < x = 3 >
+            f () match { case x(a) => 1 case y(b) => prim StrLength(b) }
+        }""",
+        "1",
+        "Int"
+    )
+
+    test(
+        "multi-case match (different bound var types, same order, second case)",
+        """{
+            def f () < x : Int, y : String > = < y = "hi" >
+            f () match { case x(a) => 1 case y(b) => prim StrLength(b) }
+        }""",
+        "2",
+        "Int"
+    )
+
+    test(
+        "multi-case match (different bound var types, different order, first case)",
+        """{
+            def f () < x : Int, y : String > = < y = "hi" >
+            f () match { case y(b) => prim StrLength(b) case x(a) => 1 }
+        }""",
+        "2",
+        "Int"
+    )
+
+    test(
+        "multi-case match (different bound var types, different order, second case)",
+        """{
+            def f () < x : Int, y : String > = < x = 3 >
+            f () match { case y(b) => prim StrLength(b) case x(a) => 1 }
+        }""",
+        "1",
         "Int"
     )
 

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/VectorTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/VectorTests.scala
@@ -8,35 +8,35 @@ class VectorTests extends ExpressionTests {
         "equality of vectors (equal, nil)",
         "equal(Vector(), [], [])",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (equal, flat)",
         "equal(Vector(Int), [1, 2, 3], [1, 2, 3])",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (equal, nested)",
         "equal(Vector({a : Int}), [{a = 1}, {a = 2}], [{a = 1}, {a = 2}])",
         "true",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (unequal, flat)",
         "equal(Vector(Int), [1, 2, 3], [1, 2])",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
         "equality of vectors (unequal, nested)",
         "equal(Vector({a : Int}), [{a = 1}, {a = 2}], [{a = 2}, {a = 2}])",
         "false",
-        "Boolean"
+        "< False : Unit, True : Unit >"
     )
 
     test(
@@ -88,7 +88,7 @@ class VectorTests extends ExpressionTests {
         "Boolean vector declaration",
         "[true, false]",
         "[true, false]",
-        "Vector(Boolean)"
+        "Vector(< False : Unit, True : Unit >)"
     )
 
     test(
@@ -98,7 +98,7 @@ class VectorTests extends ExpressionTests {
             Booleans.and(true, false),
             Booleans.and(true, true)]""",
         "[false, false, false, true]",
-        "Vector(Boolean)"
+        "Vector(< False : Unit, True : Unit >)"
     )
 
     test(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/BuiltInTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/BuiltInTests.scala
@@ -41,9 +41,9 @@ class BuiltInTests extends SemanticTests {
     )
 
     test(
-        "aliases are used in type error messages",
+        "aliases are expanded in type error messages",
         "{fun (b : Boolean) 0}(0)",
-        """|1:23:error: expected Boolean, got 0 of type Int
+        """|1:23:error: expected < False : Unit, True : Unit >, got 0 of type Int
            |{fun (b : Boolean) 0}(0)
            |                      ^
            |"""

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/DeclarationTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/DeclarationTests.scala
@@ -187,7 +187,7 @@ class DeclarationTests extends SemanticTests {
     test(
         "val explicit pre=defined type (bad)",
         "{ val x : Boolean = 1 x }",
-        """|1:21:error: expected Boolean, got 1 of type Int
+        """|1:21:error: expected < False : Unit, True : Unit >, got 1 of type Int
            |{ val x : Boolean = 1 x }
            |                    ^
            |"""

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/FunctionTypeTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/FunctionTypeTests.scala
@@ -53,7 +53,49 @@ class FunctionTypeTests extends SemanticTests {
     )
 
     test(
-        "bad type application",
+        "type application",
+        "{fun (t : Type, x : t) x}(Int)",
+        ""
+    )
+
+    test(
+        "type application (one parameterised arg)",
+        "{fun (t : Type, x : t) x}(Int, 1)",
+        ""
+    )
+
+    test(
+        "type application (two parameterised args)",
+        "{fun (t : Type, x : t, y : t) x}(Int, 1, 2)",
+        ""
+    )
+
+    test(
+        "type application (one parameterised arg with normal arg)",
+        """{fun (t : Type, x : t, s : String) x}(Int, 1, "hi")""",
+        ""
+    )
+
+    test(
+        "bad type application (mis-matched usage of parameterised arg)",
+        """{fun (t : Type, x : t) x}(Int, "hi")""",
+        """|1:32:error: expected Int, got "hi" of type String
+           |{fun (t : Type, x : t) x}(Int, "hi")
+           |                               ^
+           |"""
+    )
+
+    test(
+        "bad type application (mis-matched usage of normal arg)",
+        """{fun (t : Type, x : t, s : String) x}(Int, 1, 2)""",
+        """|1:47:error: expected String, got 2 of type Int
+           |{fun (t : Type, x : t, s : String) x}(Int, 1, 2)
+           |                                              ^
+           |"""
+    )
+
+    test(
+        "bad type application (values as types and vice versa)",
         "{fun (x : Int, t : Type) x}(Int, 10)",
         """|1:29:error: expected Int, got Int of type Type
            |{fun (x : Int, t : Type) x}(Int, 10)

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/PrimitiveTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/PrimitiveTests.scala
@@ -341,15 +341,45 @@ class PrimitiveTests extends SemanticTests {
     )
 
     test(
-        s"Partial apply equal (type only)",
+        s"full apply equal",
+        s"equal(Int, 1, 2)",
+        ""
+    )
+
+    test(
+        s"partial apply equal (type only)",
         s"equal(Int)",
         ""
     )
 
     test(
-        s"Partial apply equal (type and arg)",
+        s"partial apply equal (type and arg)",
         s"equal(Int, 1)",
         ""
+    )
+
+    test(
+        "wrong argument type for equal (type)",
+        """equal(1, 1, 1)""",
+        """|1:7:error: expected Type, got 1 of type Int
+           |equal(1, 1, 1)
+           |      ^
+           |1:10:error: expected 1, got 1 of type Int
+           |equal(1, 1, 1)
+           |         ^
+           |1:13:error: expected 1, got 1 of type Int
+           |equal(1, 1, 1)
+           |            ^
+           |"""
+    )
+
+    test(
+        "wrong argument type for equal (value)",
+        """equal(Int, 1, "2")""",
+        """|1:15:error: expected Int, got "2" of type String
+           |equal(Int, 1, "2")
+           |              ^
+           |"""
     )
 
     test(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/VectorTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/VectorTests.scala
@@ -64,4 +64,37 @@ class VectorTests extends SemanticTests {
            |"""
     )
 
+    test(
+        "bad type argument for Vector append",
+        "Vectors.append(1, 2, 3)",
+        """|1:16:error: expected Type, got 1 of type Int
+           |Vectors.append(1, 2, 3)
+           |               ^
+           |1:19:error: expected Vector(1), got 2 of type Int
+           |Vectors.append(1, 2, 3)
+           |                  ^
+           |1:22:error: expected 1, got 3 of type Int
+           |Vectors.append(1, 2, 3)
+           |                     ^
+           |"""
+    )
+
+    test(
+        "bad vector argument for Vector append",
+        "Vectors.append(Int, 2, 3)",
+        """|1:21:error: expected Vector(Int), got 2 of type Int
+           |Vectors.append(Int, 2, 3)
+           |                    ^
+           |"""
+    )
+
+    test(
+        "bad element argument for Vector append",
+        """Vectors.append(Int, [1,2], "hi")""",
+        """|1:28:error: expected Int, got "hi" of type String
+           |Vectors.append(Int, [1,2], "hi")
+           |                           ^
+           |"""
+    )
+
 }

--- a/truffle/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/nodes/term/CoomaTermParser.rats
+++ b/truffle/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/nodes/term/CoomaTermParser.rats
@@ -71,7 +71,7 @@ public CoomaCaseTerm CaseTerm =
     ;
 
 public CoomaDefTerm DefTerm =
-     f:Identifier k:Identifier x:Identifier  void:"=":Symbol1 t:Term {
+    void:"%def":Symbol4 f:Identifier k:Identifier x:Identifier  void:"=":Symbol1 t:Term {
         yyValue = (CoomaDefTerm)backend.defTerm(f, k, x, t);
     }
     ;
@@ -244,7 +244,7 @@ String Symbol4 =
     Symbol4Alts Spacing;
 
 transient String Symbol4Alts =
-    "%fun";
+    "%def" / "%fun";
 
 String Symbol5 =
     Symbol5Alts Spacing;


### PR DESCRIPTION
* Remove aliasing of types on output since there is no guarantee that the alias we choose is the most meaningful one for the user.

* Properly check argument types in the presence of type parameters.

* Put proper checking of REPL types back in since type parameters are now checked properly. Previously we allowed some untypeable expressions to go through since they ran correctly.

* Fix doing name lookup for case-bound variable types instead of position-based (fixes #43).

* Support a limited form of type constructor (aka function that takes type(s) and returns a type). Since we don't have full evaluation at compile time, we just support forms that are directly defined as functions, so we can just do a simple substitution of type arguments. See the prelude for some examples.

* Add definitions of `Option` and `Either` to prelude.

* Fix some bugs in parsing the static and dynamic prelude files revealed when extending the prelude. We needed more separators to avoid some ambiguity, so added semicolon separators in static files and a `%def` keyword for def terms in dynamic files.
