### PR TITLE
Pass semantic analyser to compiler

### DIFF
--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
@@ -18,19 +18,19 @@ trait Compiler {
     import org.bitbucket.inkytonik.cooma.Util.resetFresh
     import org.bitbucket.inkytonik.kiama.util.Positions
 
-    def compileCommand(prog : Program, positions : Positions) : Term = {
+    def compileCommand(prog : Program, positions : Positions, analyser : SemanticAnalyser) : Term = {
         resetFresh()
-        val compiler = new CompilerCore(positions)
+        val compiler = new CompilerCore(positions, analyser)
         compiler.compileTop(prog.expression, 0)
     }
 
-    def compileStandalone(prog : Program, positions : Positions) : Term = {
+    def compileStandalone(prog : Program, positions : Positions, analyser : SemanticAnalyser) : Term = {
         resetFresh()
-        val compiler = new CompilerCore(positions)
+        val compiler = new CompilerCore(positions, analyser)
         compiler.compileHalt(prog.expression)
     }
 
-    class CompilerCore(positions : Positions) {
+    class CompilerCore(positions : Positions, analyser : SemanticAnalyser) {
 
         import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.{
             CaseTerm => _,

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Config.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Config.scala
@@ -62,4 +62,12 @@ class Config(args : Seq[String]) extends REPLConfig(args) {
         descr = "Print the program's usage message (default: false)",
         default = Some(false))
 
+    override def hashCode : Int = args.hashCode
+
+    override def equals(o : Any) : Boolean =
+        o match {
+            case other : Config => this.args == other.args
+            case _              => false
+        }
+
 }

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -45,6 +45,9 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
             compileFile(config.filenames()(0), config)
     }
 
+    def getAnalyser(source : Source) : SemanticAnalyser =
+        analysers.getOrElse(source, throw new RuntimeException(s"no analyser for $source"))
+
     val analysers = scala.collection.mutable.Map[Source, SemanticAnalyser]()
 
     override def compileSource(source : Source, config : Config) : Unit = {

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/REPL.scala
@@ -118,8 +118,8 @@ trait REPL extends REPLBase[Config] {
                 checkInput(input, config) match {
                     case Left(messages) =>
                         messaging.report(source, messages, config.output())
-                    case Right((input, optTypeValue, optReplType)) =>
-                        processInput(input, optTypeValue, optReplType, config)
+                    case Right(CheckedInput(input, optTypeValue, optReplType, analyser)) =>
+                        processInput(input, optTypeValue, optReplType, config, analyser)
                 }
             } else
                 config.output().emitln(p.formatParseError(pr.parseError, false))
@@ -139,10 +139,17 @@ trait REPL extends REPLBase[Config] {
         REPLLet(let)
     }
 
+    case class CheckedInput(
+        input : REPLInput,
+        typeValue : Option[Expression],
+        replType : Option[Expression],
+        analyser : SemanticAnalyser
+    )
+
     def checkInput(
         input : REPLInput,
         config : Config
-    ) : Either[Messages, (REPLInput, Option[Expression], Option[Expression])] = {
+    ) : Either[Messages, CheckedInput] = {
         if (config.coomaASTPrint())
             config.output().emitln(layout(any(input), 5))
         val tree = new Tree[ASTNode, REPLInput](input)
@@ -171,7 +178,7 @@ trait REPL extends REPLBase[Config] {
                         case REPLLet(Let(_, IdnDef(i), Some(LetType(t)), e)) =>
                             defineLet(i, optTypeValue, analyser.unalias(e, t), e)
                     }
-                Right((input2, optTypeValue, optReplType))
+                Right(CheckedInput(input2, optTypeValue, optReplType, analyser))
 
             case (messages, _, _) =>
                 Left(messages)
@@ -181,14 +188,20 @@ trait REPL extends REPLBase[Config] {
     /**
      * Embed an input entry for the REPL.
      */
-    def processInput(input : REPLInput, optTypeValue : Option[Expression], optReplType : Option[Expression], config : Config) =
+    def processInput(
+        input : REPLInput,
+        optTypeValue : Option[Expression],
+        optReplType : Option[Expression],
+        config : Config,
+        analyser : SemanticAnalyser
+    ) : Unit =
         input match {
             case REPLDef(fd @ Def(IdnDef(i), _)) =>
-                processDef(i, fd, optTypeValue, optReplType, config)
+                processDef(i, fd, optTypeValue, optReplType, config, analyser)
             case REPLExp(e : Idn) =>
-                processIdn(show(input), e, optTypeValue, optReplType, config)
+                processIdn(show(input), e, optTypeValue, optReplType, config, analyser)
             case REPLLet(vd @ Let(_, IdnDef(i), _, e)) =>
-                processLet(i, vd, optTypeValue, optReplType, config)
+                processLet(i, vd, optTypeValue, optReplType, config, analyser)
             case _ =>
                 sys.error(s"$input not supported for the moment")
         }
@@ -196,25 +209,46 @@ trait REPL extends REPLBase[Config] {
     /**
      * Process a user-entered value binding.
      */
-    def processLet(i : String, ld : Let, optTypeValue : Option[Expression], optReplType : Option[Expression], config : Config) : Unit = {
+    def processLet(
+        i : String,
+        ld : Let,
+        optTypeValue : Option[Expression],
+        optReplType : Option[Expression],
+        config : Config,
+        analyser : SemanticAnalyser
+    ) : Unit = {
         val program = Program(Blk(BlkLet(ld, Return(Idn(IdnUse(i))))))
-        process(program, i, optTypeValue, optReplType, config)
+        process(program, i, optTypeValue, optReplType, config, analyser)
     }
 
     /**
      * Process a user-entered function definition binding.
      */
-    def processDef(i : String, fd : Def, optTypeValue : Option[Expression], optReplType : Option[Expression], config : Config) : Unit = {
+    def processDef(
+        i : String,
+        fd : Def,
+        optTypeValue : Option[Expression],
+        optReplType : Option[Expression],
+        config : Config,
+        analyser : SemanticAnalyser
+    ) : Unit = {
         val program = Program(Blk(BlkDef(Defs(Vector(fd)), Return(Idn(IdnUse(i))))))
-        process(program, i, optTypeValue, optReplType, config)
+        process(program, i, optTypeValue, optReplType, config, analyser)
     }
 
     /**
      * Process a user-entered identifier expression.
      */
-    def processIdn(i : String, e : Expression, optTypeValue : Option[Expression], optReplType : Option[Expression], config : Config) : Unit = {
+    def processIdn(
+        i : String,
+        e : Expression,
+        optTypeValue : Option[Expression],
+        optReplType : Option[Expression],
+        config : Config,
+        analyser : SemanticAnalyser
+    ) : Unit = {
         val program = Program(e)
-        process(program, i, optTypeValue, optReplType, config)
+        process(program, i, optTypeValue, optReplType, config, analyser)
     }
 
     /**
@@ -225,7 +259,8 @@ trait REPL extends REPLBase[Config] {
         i : String,
         optTypeValue : Option[Expression],
         optReplType : Option[Expression],
-        config : Config
+        config : Config,
+        analyser : SemanticAnalyser
     ) : Unit
 
     /**

--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/PreludeDriver.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/PreludeDriver.scala
@@ -83,7 +83,7 @@ class PreludeDriver extends Driver {
         val system = new ReferenceBackend(this, source, config) with Compiler
         import system.{source => _, _}
 
-        val prelude = compileCommand(program, positions)
+        val prelude = compileCommand(program, positions, getAnalyser(source))
         val preludeText = PrettyPrinter.format(prelude, 5).layout
         val filename = s"${source.name}.dynamic"
         val emitter = new FileEmitter(filename)

--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/ReferenceFrontend.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/ReferenceFrontend.scala
@@ -53,7 +53,7 @@ class ReferenceDriver extends REPLDriver {
 
     override def process(source : Source, program : Program, config : Config) : Unit = {
         val system = new ReferenceBackend(this, source, config) with Compiler
-        val term = system.compileCommand(program, positions)
+        val term = system.compileCommand(program, positions, getAnalyser(source))
         if (config.irPrint())
             config.output().emitln(system.showTerm(term))
         if (config.irASTPrint())

--- a/reference/src/main/scala/org/bitbucket/inkytonik/cooma/ReferenceREPL.scala
+++ b/reference/src/main/scala/org/bitbucket/inkytonik/cooma/ReferenceREPL.scala
@@ -35,9 +35,10 @@ trait ReferenceREPL extends REPL {
         i : String,
         optTypeValue : Option[Expression],
         optAliasedType : Option[Expression],
-        config : Config
+        config : Config,
+        analyser : SemanticAnalyser
     ) : Unit = {
-        val term = compileStandalone(program, positions)
+        val term = compileStandalone(program, positions, analyser)
 
         if (config.irPrint())
             config.output().emitln(showTerm(term))

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/BackendConfig.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/BackendConfig.scala
@@ -1,0 +1,19 @@
+package org.bitbucket.inkytonik.cooma.test
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+import org.bitbucket.inkytonik.cooma.{Frontend, ReferenceFrontend}
+import org.bitbucket.inkytonik.cooma.truffle.TruffleFrontend
+
+case class BackendConfig(name : String, frontend : Frontend, options : Seq[String])
+
+object BackendConfig {
+
+    lazy val truffleOutContent = new ByteArrayOutputStream
+
+    lazy val backends = Seq(
+        BackendConfig("Reference", new ReferenceFrontend, Seq()),
+        BackendConfig("GraalVM", new TruffleFrontend(out = new PrintStream(truffleOutContent)), Seq("-g"))
+    )
+
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/ExecutionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/ExecutionTests.scala
@@ -1,26 +1,18 @@
 package org.bitbucket.inkytonik.cooma.test
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-
-import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.{ASTNode, Program}
-import org.bitbucket.inkytonik.cooma.truffle.{TruffleDriver, TruffleFrontend}
-import org.bitbucket.inkytonik.cooma.{Backend, Compiler, Config, Frontend, Main, REPL, REPLDriver, ReferenceDriver, ReferenceFrontend}
-import org.bitbucket.inkytonik.kiama.util.{Source, StringConsole, TestCompilerWithConfig}
+import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.Program
+import org.bitbucket.inkytonik.cooma.test.BackendConfig._
+import org.bitbucket.inkytonik.cooma.truffle.TruffleDriver
+import org.bitbucket.inkytonik.cooma.{Backend, Compiler, Config, Main, REPL, REPLDriver, ReferenceDriver}
+import org.bitbucket.inkytonik.kiama.util.{Source, StringConsole}
 import org.rogach.scallop.throwError
 import org.scalactic.source.Position
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should
 
 import scala.util.{Failure, Success, Try}
 
-trait ExecutionTests extends REPLDriver with TestCompilerWithConfig[ASTNode, Program, Config] {
-
-    case class BackendConfig(name : String, frontend : Frontend, options : Seq[String])
-
-    val truffleOutContent = new ByteArrayOutputStream
-
-    val backends = Seq(
-        BackendConfig("Reference", new ReferenceFrontend, Seq()),
-        BackendConfig("GraalVM", new TruffleFrontend(out = new PrintStream(truffleOutContent)), Seq("-g"))
-    )
+trait ExecutionTests extends REPLDriver with AnyFunSuiteLike with should.Matchers {
 
     def test(name : String)(f : BackendConfig => Any)(implicit pos : Position) : Unit =
         for (bc <- backends) super.test(f"[${bc.name}] $name")(f(bc))
@@ -117,13 +109,6 @@ trait ExecutionTests extends REPLDriver with TestCompilerWithConfig[ASTNode, Pro
     override def process(source : Source, prog : Program, config : Config) : Unit = {
         val driver = createDriver(config)
         driver.process(source, prog, config)
-    }
-
-    override def testdriver(config : Config) : Unit = {
-        if (config.graalVM())
-            new TruffleFrontend().interpret(config)
-        else
-            super.testdriver(config)
     }
 
 }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/ExpressionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/ExpressionTests.scala
@@ -1,6 +1,6 @@
 package org.bitbucket.inkytonik.cooma.test
 
-class ExpressionTests extends ExecutionTests {
+trait ExpressionTests extends ExecutionTests {
 
     def test(
         name : String,

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/FileTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/FileTests.scala
@@ -2,45 +2,53 @@ package org.bitbucket.inkytonik.cooma.test
 
 import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.{ASTNode, Program}
 import org.bitbucket.inkytonik.cooma.truffle.{TruffleDriver, TruffleFrontend}
-import org.bitbucket.inkytonik.cooma.{Backend, Compiler, Config, REPL, REPLDriver, ReferenceDriver}
-import org.bitbucket.inkytonik.kiama.util.{Source, TestCompilerWithConfig}
+import org.bitbucket.inkytonik.cooma.{Config, REPLDriver, ReferenceDriver}
+import org.bitbucket.inkytonik.kiama.output.PrettyPrinterTypes
+import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
+import org.bitbucket.inkytonik.kiama.util.{CompilerBase, Source, TestCompilerWithConfig}
 import org.rogach.scallop.throwError
 
-trait FileTests extends REPLDriver with TestCompilerWithConfig[ASTNode, Program, Config] {
+import scala.collection.mutable
+
+trait FileTests extends TestCompilerWithConfig[ASTNode, Program, Config] with CompilerBase[ASTNode, Program, Config] {
+
+    val drivers = mutable.Map.empty[Config, REPLDriver]
+
+    override def name : String = "cooma"
+
+    override def makeast(source : Source, config : Config) : Either[Program, Messages] =
+        createDriver(config).makeast(source, config)
+
+    override def format(ast : Program) : PrettyPrinterTypes.Document =
+        (new ReferenceDriver).format(ast)
 
     override def createConfig(args : Seq[String]) : Config = {
         // set Scallop so that errors don't just exit the process
         val saveThrowError = throwError.value
         throwError.value = true
-        val config = super.createConfig(args)
+        val config = new Config(args)
         config.verify()
         throwError.value = saveThrowError
         config
     }
 
     def createDriver(config : Config) : REPLDriver =
-        if (config.graalVM())
-            new TruffleDriver
-        else
-            new ReferenceDriver
+        drivers.getOrElseUpdate(
+            config,
+            if (config.graalVM()) new TruffleDriver
+            else new ReferenceDriver
+        )
 
-    override def createREPL(config : Config) : REPL with Compiler with Backend = {
-        val driver = createDriver(config)
-        val repl = driver.createREPL(config)
-        repl.initialise(config)
-        repl
-    }
-
-    override def process(source : Source, prog : Program, config : Config) : Unit = {
+    def process(source : Source, prog : Program, config : Config) : Unit = {
         val driver = createDriver(config)
         driver.process(source, prog, config)
     }
 
     override def testdriver(config : Config) : Unit = {
         if (config.graalVM())
-            new TruffleFrontend().interpret(config)
+            (new TruffleFrontend).interpret(config)
         else
-            super.testdriver(config)
+            createDriver(config).run(config)
     }
 
 }

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/FileTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/FileTests.scala
@@ -1,0 +1,46 @@
+package org.bitbucket.inkytonik.cooma.test
+
+import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.{ASTNode, Program}
+import org.bitbucket.inkytonik.cooma.truffle.{TruffleDriver, TruffleFrontend}
+import org.bitbucket.inkytonik.cooma.{Backend, Compiler, Config, REPL, REPLDriver, ReferenceDriver}
+import org.bitbucket.inkytonik.kiama.util.{Source, TestCompilerWithConfig}
+import org.rogach.scallop.throwError
+
+trait FileTests extends REPLDriver with TestCompilerWithConfig[ASTNode, Program, Config] {
+
+    override def createConfig(args : Seq[String]) : Config = {
+        // set Scallop so that errors don't just exit the process
+        val saveThrowError = throwError.value
+        throwError.value = true
+        val config = super.createConfig(args)
+        config.verify()
+        throwError.value = saveThrowError
+        config
+    }
+
+    def createDriver(config : Config) : REPLDriver =
+        if (config.graalVM())
+            new TruffleDriver
+        else
+            new ReferenceDriver
+
+    override def createREPL(config : Config) : REPL with Compiler with Backend = {
+        val driver = createDriver(config)
+        val repl = driver.createREPL(config)
+        repl.initialise(config)
+        repl
+    }
+
+    override def process(source : Source, prog : Program, config : Config) : Unit = {
+        val driver = createDriver(config)
+        driver.process(source, prog, config)
+    }
+
+    override def testdriver(config : Config) : Unit = {
+        if (config.graalVM())
+            new TruffleFrontend().interpret(config)
+        else
+            super.testdriver(config)
+    }
+
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/BasicFileTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/BasicFileTests.scala
@@ -1,8 +1,9 @@
 package org.bitbucket.inkytonik.cooma.test.execution
 
-import org.bitbucket.inkytonik.cooma.test.ExecutionTests
+import org.bitbucket.inkytonik.cooma.test.BackendConfig._
+import org.bitbucket.inkytonik.cooma.test.FileTests
 
-class FileTests extends ExecutionTests {
+class BasicFileTests extends FileTests {
 
     val resourcesPath = "src/test/resources"
 

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/OptionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/OptionTests.scala
@@ -1,9 +1,9 @@
 package org.bitbucket.inkytonik.cooma.test.execution
 
 import org.bitbucket.inkytonik.cooma.ReferenceFrontend
-import org.bitbucket.inkytonik.cooma.test.ExecutionTests
+import org.bitbucket.inkytonik.cooma.test.{BackendConfig, FileTests}
 
-class OptionTests extends ExecutionTests {
+class OptionTests extends FileTests {
 
     val resourcesPath = "src/test/resources"
 

--- a/truffle_root/src/main/java/org/bitbucket/inkytonik/cooma/truffle/TruffleDriver.java
+++ b/truffle_root/src/main/java/org/bitbucket/inkytonik/cooma/truffle/TruffleDriver.java
@@ -14,23 +14,31 @@ import org.bitbucket.inkytonik.cooma.Config;
 import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.Program;
 import org.bitbucket.inkytonik.cooma.REPLDriver;
 import org.bitbucket.inkytonik.cooma.REPL;
+import org.bitbucket.inkytonik.cooma.SemanticAnalyser;
 import org.bitbucket.inkytonik.cooma.truffle.nodes.term.CoomaTermNode;
 import org.bitbucket.inkytonik.kiama.util.Source;
 
 public class TruffleDriver extends REPLDriver {
 
     private CoomaTermNode currentCompiledNode;
+    private SemanticAnalyser analyser;
 
     @Override
     public REPL createREPL(Config config) {
-        return TruffleReplFrontendHolder.repl(config);
+        return TruffleReplFrontendHolder.repl(config, this);
     }
 
     @Override
     public void process(Source source, Program program, Config config) {
-        if (!config.usage().isSupplied()) {
-            TruffleCompiler compiler = new TruffleCompiler(config);
-            setCurrentCompiledNode(compiler.compileCommand(program));
+        try {
+            if (!config.usage().isSupplied()) {
+                TruffleCompiler compiler = new TruffleCompiler(config, analyser);
+                setCurrentCompiledNode(compiler.compileCommand(program));
+            }
+        }
+        catch (RuntimeException e) {
+            e.printStackTrace();
+            throw e;
         }
     }
 
@@ -42,4 +50,7 @@ public class TruffleDriver extends REPLDriver {
         this.currentCompiledNode = currentCompiledNode;
     }
 
+    public void setAnalyser(SemanticAnalyser analyser) {
+        this.analyser = analyser;
+    }
 }

--- a/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleCompiler.scala
+++ b/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleCompiler.scala
@@ -11,9 +11,9 @@
 package org.bitbucket.inkytonik.cooma.truffle
 
 import org.bitbucket.inkytonik.cooma.truffle.nodes.term.CoomaTermNode
-import org.bitbucket.inkytonik.cooma.{Config, CoomaParserSyntax}
+import org.bitbucket.inkytonik.cooma.{Config, CoomaParserSyntax, SemanticAnalyser}
 
-class TruffleCompiler(val config : Config) {
+class TruffleCompiler(val config : Config, analyser : SemanticAnalyser) {
 
     import org.bitbucket.inkytonik.cooma.Compiler
     import org.bitbucket.inkytonik.kiama.util.Positions
@@ -21,7 +21,7 @@ class TruffleCompiler(val config : Config) {
     val backendMixin = new TruffleBackend(config) with Compiler
 
     def compileCommand(prog : CoomaParserSyntax.Program) : CoomaTermNode = {
-        backendMixin.compileCommand(prog, new Positions)
+        backendMixin.compileCommand(prog, new Positions, analyser)
     }
 
     def showTerm(t : CoomaTermNode) : String = backendMixin.showTerm(t)

--- a/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleREPL.scala
+++ b/truffle_root/src/main/scala/org/bitbucket/inkytonik/cooma/truffle/TruffleREPL.scala
@@ -20,6 +20,8 @@ trait TruffleREPL extends REPL {
 
     self : Compiler with TruffleBackend =>
 
+    def driver : TruffleDriver
+
     import org.bitbucket.inkytonik.cooma.Config
     import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.{Expression, Program}
     import org.bitbucket.inkytonik.cooma.PrettyPrinter.format
@@ -37,8 +39,10 @@ trait TruffleREPL extends REPL {
         i : String,
         optTypeValue : Option[Expression],
         optAliasedType : Option[Expression],
-        config : Config
+        config : Config,
+        analyser : SemanticAnalyser
     ) : Unit = {
+        driver.setAnalyser(analyser)
         execute(i, optTypeValue, optAliasedType, config, {
             val line = format(program).layout
             Try(currentDynamicEnv.eval(CoomaConstants.ID, line)).toEither match {
@@ -55,6 +59,6 @@ trait TruffleREPL extends REPL {
 }
 
 object TruffleReplFrontendHolder {
-    def repl(config : Config) : REPL with Compiler with Backend =
-        new TruffleBackend(config) with TruffleREPL with Compiler
+    def repl(config : Config, td : TruffleDriver) : REPL with Compiler with Backend =
+        new TruffleBackend(config) with TruffleREPL with Compiler { override val driver = td }
 }


### PR DESCRIPTION
This PR provides the compiler with access to the semantic analyser output.

The `CompilerCore` constructor now takes `analyser : SemanticAnalyser` as a parameter. The `compileCommand` and `compileStandalone` methods also take this parameter so it can be passed on to the constructor.

### Compiler (non-REPL)

`Driver` currently contains `analysers : mutable.Map[Source, SemanticAnalyser]`, which is updated in `checkProgram`. The respective analyser is passed to `process` (and ultimately to the `CompilerCore` constructor) using this map.

### Reference REPL

For the reference REPL, `REPL::checkInput` is where the semantic analysis takes place. This method now returns the semantic analyser. From `REPL::enterline`, the analyser is passed through methods ultimately to the constructor of `CompilerCore`.

### Truffle REPL

A bit of a hack has been employed here. The Truffle REPL needs to be able to communicate the analyser back to the driver, so that the driver can pass it onto the compiler. To achieve this, `TruffleDriver` now has an `analyser : SemanticAnalyser` field with a setter. `TruffleDriver` also passes _itself_ as a parameter to the REPL constructor, so that the REPL can invoke `setAnalyser` on the driver.