### PR TITLE
Top-level rewriter

### DIFF
--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
@@ -12,8 +12,6 @@ package org.bitbucket.inkytonik.cooma
 
 import org.bitbucket.inkytonik.cooma.primitive.database.Metadata
 
-import scala.annotation.tailrec
-
 trait Compiler {
 
     self : Backend =>
@@ -170,26 +168,6 @@ trait Compiler {
                     compileTopArg(arg, a, t, e)
                 case Fun(Arguments((arg @ Argument(IdnDef(a), t, _)) +: as), e) =>
                     compileTopArg(arg, a, t, Fun(Arguments(as), e))
-                case Blk(blockExp) =>
-                    @tailrec
-                    def aux(
-                        blockExp : BlockExp,
-                        f : BlockExp => BlockExp
-                    ) : Term =
-                        blockExp match {
-                            case BlkDef(defs, blockExp) =>
-                                aux(blockExp, e => f(BlkDef(defs, e)))
-                            case BlkLet(let, blockExp) =>
-                                aux(blockExp, e => f(BlkLet(let, e)))
-                            case Return(Fun(args, body)) =>
-                                // main function
-                                val precompiled = Fun(args, Blk(f(Return(body))))
-                                compileTop(precompiled, nArg)
-                            case Return(_) =>
-                                // nullary program
-                                compileHalt(exp)
-                        }
-                    aux(blockExp, identity)
                 case _ =>
                     compileHalt(exp)
             }

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Compiler.scala
@@ -12,6 +12,8 @@ package org.bitbucket.inkytonik.cooma
 
 import org.bitbucket.inkytonik.cooma.primitive.database.Metadata
 
+import scala.annotation.tailrec
+
 trait Compiler {
 
     self : Backend =>
@@ -168,6 +170,26 @@ trait Compiler {
                     compileTopArg(arg, a, t, e)
                 case Fun(Arguments((arg @ Argument(IdnDef(a), t, _)) +: as), e) =>
                     compileTopArg(arg, a, t, Fun(Arguments(as), e))
+                case Blk(blockExp) =>
+                    @tailrec
+                    def aux(
+                        blockExp : BlockExp,
+                        f : BlockExp => BlockExp
+                    ) : Term =
+                        blockExp match {
+                            case BlkDef(defs, blockExp) =>
+                                aux(blockExp, e => f(BlkDef(defs, e)))
+                            case BlkLet(let, blockExp) =>
+                                aux(blockExp, e => f(BlkLet(let, e)))
+                            case Return(Fun(args, body)) =>
+                                // main function
+                                val precompiled = Fun(args, Blk(f(Return(body))))
+                                compileTop(precompiled, nArg)
+                            case Return(_) =>
+                                // nullary program
+                                compileHalt(exp)
+                        }
+                    aux(blockExp, identity)
                 case _ =>
                     compileHalt(exp)
             }

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -20,7 +20,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
     import org.bitbucket.inkytonik.cooma.PrettyPrinter.{any, layout, pretty, show}
     import org.bitbucket.inkytonik.cooma.SymbolTable.{Environment, capabilityTypeNames, preludeStaticEnv, StrT}
     import org.bitbucket.inkytonik.kiama.output.PrettyPrinterTypes.Document
-    import org.bitbucket.inkytonik.kiama.relation.Tree
+    import org.bitbucket.inkytonik.kiama.relation.{EnsureTree, Tree}
     import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, noMessages}
     import org.bitbucket.inkytonik.kiama.util.Source
 
@@ -98,7 +98,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
         if (!config.server() && config.filenames().isEmpty) {
             noMessages
         } else {
-            val tree = new Tree[ASTNode, Program](program)
+            val tree = new Tree[ASTNode, Program](program, EnsureTree)
             val analyser = new SemanticAnalyser(tree, env)
             analysers.get(source) match {
                 case Some(prevAnalyser) =>
@@ -107,7 +107,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
                 // Do nothing
             }
             analysers(source) = analyser
-            analyser.tipe(program.expression) match {
+            analyser.tipe(tree.root.expression) match {
                 case Some(tipe) =>
                     if (config.typePrint())
                         config.output().emitln(show(tipe))

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/Driver.scala
@@ -75,7 +75,7 @@ abstract class Driver extends CompilerBase[ASTNode, Program, Config] with Server
                 publishSourceTreeProduct(source, pretty(any(program)))
             }
             val env = preludeStaticEnv(config)
-            desugar(program, env, positions) match {
+            desugar(program, env, positions).flatMap(TopLevelRewriter(_)) match {
                 case Left(messages) =>
                     Right(messages)
                 case Right(desugaredProgram) =>

--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/TopLevelRewriter.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/TopLevelRewriter.scala
@@ -1,0 +1,133 @@
+package org.bitbucket.inkytonik.cooma
+
+import org.bitbucket.inkytonik.cooma.CoomaParserSyntax._
+import org.bitbucket.inkytonik.kiama.util.Messaging._
+
+import scala.annotation.tailrec
+
+object TopLevelRewriter {
+
+    def apply(program : Program) : Either[Messages, Program] =
+        program.expression match {
+            case Blk(blockExp) =>
+                @tailrec
+                def aux(
+                    blockExp : BlockExp,
+                    lets : Vector[Let],
+                    defs : Vector[Def]
+                ) : Either[Messages, Program] =
+                    blockExp match {
+                        case BlkDef(Defs(newDefs), next) =>
+                            aux(next, lets, defs ++ newDefs)
+                        case BlkLet(let, next) =>
+                            aux(next, lets :+ let, defs)
+                        case Return(Fun(Arguments(args), body)) =>
+                            // main function
+                            if (defs.isEmpty) rewriteMain(lets, args, body).map(Program)
+                            else Left(defs.flatMap(error(_, "def not allowed here")))
+                        case Return(_) =>
+                            // nullary program
+                            Right(program)
+                    }
+                aux(blockExp, Vector(), Vector())
+            case _ =>
+                Right(program)
+        }
+
+    def rewriteMain(
+        lets : Seq[Let],
+        args : Seq[Argument],
+        body : Expression
+    ) : Either[Messages, Expression] =
+        for {
+            env <- rewriteLets(lets)
+            argsr <- rewriteArgs(args, env)
+        } yield {
+            def aux(lets : Seq[Let]) : BlockExp =
+                lets match {
+                    case hd +: tl => BlkLet(hd, aux(tl))
+                    case _        => Return(body)
+                }
+            Fun(Arguments(argsr.toVector), Blk(aux(lets)))
+        }
+
+    def rewriteLets(lets : Seq[Let]) : Either[Messages, Map[String, Expression]] = {
+        val zero : Either[Messages, Map[String, Expression]] = Right(Map.empty)
+        lets.foldLeft(zero) {
+            case (out, Let(_, IdnDef(name), _, exp)) =>
+                out.flatMap(env => rewrite(exp, env).map(exp => env + (name -> exp)))
+        }
+    }
+
+    def rewriteArgs(
+        args : Seq[Argument],
+        env : Map[String, Expression]
+    ) : Either[Messages, Seq[Argument]] = {
+        val rewritten = args.map { case Argument(idn, exp, doc) => rewrite(exp, env).map(Argument(idn, _, doc)) }
+        validate(rewritten).left.map(_.toVector)
+    }
+
+    def rewrite(
+        exp : Expression,
+        env : Map[String, Expression]
+    ) : Either[Messages, Expression] = {
+        // returns rewritten body (right) or sequence of illegal expressions (left)
+        def aux(
+            exp : Expression,
+            env : Map[String, Expression]
+        ) : Either[Seq[Expression], Expression] =
+            exp match {
+                case Cat(e1, e2) =>
+                    val e1r = aux(e1, env)
+                    val e2r = aux(e2, env)
+                    (e1r, e2r) match {
+                        case (Right(e1r), Right(e2r)) => Right(Cat(e1r, e2r))
+                        case _                        => Left(collectErrors(Seq(e1r, e2r)))
+                    }
+                case App(f, args) =>
+                    val fr = aux(f, env)
+                    val argsr = validate(args.map(aux(_, env)))
+                    (fr, argsr) match {
+                        case (Right(fr), Right(argsr)) => Right(App(fr, argsr.toVector))
+                        case _                         => Left(collectErrors(Seq(fr, argsr)))
+                    }
+                case RecT(flds) =>
+                    val fldsr = flds.map { case FieldType(name, exp) => aux(exp, env).map(FieldType(name, _)) }
+                    validate(fldsr).map(_.toVector).map(RecT)
+                case VarT(flds) =>
+                    val fldsr = flds.map { case FieldType(name, exp) => aux(exp, env).map(FieldType(name, _)) }
+                    validate(fldsr).map(_.toVector).map(VarT)
+                case VecNilT() =>
+                    Right(VecNilT())
+                case VecT(e) =>
+                    aux(e, env).map(VecT)
+                case Idn(IdnUse(idn)) =>
+                    env.get(idn) match {
+                        case Some(exp) => aux(exp, env)
+                        case None      => Right(exp)
+                    }
+                case exp =>
+                    Left(Seq(exp))
+            }
+        aux(exp, env).left.map(_.flatMap(error(_, "not allowed here")).toVector)
+    }
+
+    /** Flattens a sequence of results whose failures may contain multiple errors. */
+    def validate[A, B](results : Seq[Either[Seq[A], B]]) : Either[Seq[A], Seq[B]] = {
+        val zero : Either[Seq[A], Seq[B]] = Right(Seq())
+        results.foldLeft(zero) {
+            case (Right(xs), Right(x))           => Right(xs :+ x)
+            case (Right(_), Left(errors))        => Left(errors)
+            case (Left(errors), Right(_))        => Left(errors)
+            case (Left(errors), Left(newErrors)) => Left(errors ++ newErrors)
+        }
+    }
+
+    /** Similar to `validate` but assumes the result is a failure. */
+    def collectErrors[A](results : Seq[Either[Seq[A], Any]]) : Seq[A] =
+        results.flatMap {
+            case Right(_) => Seq()
+            case Left(xs) => xs
+        }
+
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/SemanticTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/SemanticTests.scala
@@ -3,7 +3,7 @@ package org.bitbucket.inkytonik.cooma.test
 import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.{ASTNode, Program}
 import org.bitbucket.inkytonik.cooma.{ReferenceDriver, SemanticAnalyser}
 import org.bitbucket.inkytonik.cooma.SymbolTable.preludeStaticEnv
-import org.bitbucket.inkytonik.kiama.relation.Tree
+import org.bitbucket.inkytonik.kiama.relation.{EnsureTree, Tree}
 import org.bitbucket.inkytonik.kiama.util.{StringSource, Tests}
 
 trait SemanticTests extends Tests {
@@ -24,7 +24,7 @@ trait SemanticTests extends Tests {
         val messages =
             driver.makeast(StringSource(expression), config) match {
                 case Left(ast) =>
-                    val tree = new Tree[ASTNode, Program](ast)
+                    val tree = new Tree[ASTNode, Program](ast, EnsureTree)
                     val env = preludeStaticEnv(config)
                     val analyser = new SemanticAnalyser(tree, env)
                     analyser.errors

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/execution/expression/FunctionTests.scala
@@ -90,10 +90,10 @@ class FunctionTests extends ExpressionTests {
     )
 
     test(
-        "function program result (type arg)",
-        "{fun (t : Type, x : t) x}",
-        "<function>",
-        "(t : Type, x : t) t"
+        "function with type arg",
+        "{val f = fun (t : Type, x : t) x { }}",
+        "{}",
+        "Unit"
     )
 
     test(

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/FunctionTypeTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/FunctionTypeTests.scala
@@ -48,7 +48,7 @@ class FunctionTypeTests extends SemanticTests {
 
     test(
         "type argument",
-        "{fun (t : Type, x : t) x}",
+        "{val f = fun (t : Type, x : t) x { } }",
         ""
     )
 

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/TopLevelRewriterTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/TopLevelRewriterTests.scala
@@ -1,0 +1,202 @@
+package org.bitbucket.inkytonik.cooma.test.semantic
+
+import org.bitbucket.inkytonik.cooma.CoomaParserSyntax.Program
+import org.bitbucket.inkytonik.cooma.Desugar.desugar
+import org.bitbucket.inkytonik.cooma.SymbolTable.loadPrelude
+import org.bitbucket.inkytonik.cooma.{CoomaParser, TopLevelRewriter}
+import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
+import org.bitbucket.inkytonik.kiama.util.{Positions, StringSource}
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should
+
+class TopLevelRewriterTests extends AnyFunSuiteLike with should.Matchers with EitherValues {
+
+    def compile(source : String) : Program = {
+        val positions = new Positions
+        val parser = new CoomaParser(StringSource(source), positions)
+        val result = parser.pProgram(0)
+        val program = parser.value(result).asInstanceOf[Program]
+        val env = loadPrelude(s"./prelude/prelude.cooma.static").toOption.get
+        desugar(program, env, positions).toOption.get
+    }
+
+    def check(source : String, f : Either[Messages, Program] => Unit) : Unit =
+        f(TopLevelRewriter(compile(source)))
+
+    def test(name : String, source : String, expected : String) : Unit =
+        test(name) {
+            val program = TopLevelRewriter(compile(source))
+            program.value shouldEqual compile(expected)
+        }
+
+    def test(name : String, source : String, expected : Seq[String]) : Unit =
+        test(name) {
+            val program = TopLevelRewriter(compile(source))
+            program.left.value.map(_.label) shouldEqual expected.toVector
+        }
+
+    test("do not rewrite a program consisting of a non-block expression", "0", "0")
+
+    test(
+        "do not rewrite a program containing a top-level function",
+        """fun (name: String) { val prefix = "Hello " concat(prefix, name) }""",
+        """fun (name: String) { val prefix = "Hello " concat(prefix, name) }""",
+    )
+
+    test(
+        "do not rewrite a program consisting of a block with a non-function return",
+        """{ val x = 42 (fun (x: Int) x + 1) x }""",
+        """{ val x = 42 (fun (x: Int) x + 1) x }""",
+    )
+
+    test(
+        "reject top-level defs",
+        """|{
+           |    def Box (A : Type) Type = { value : A }
+           |    def box (A : Type, value : A) Box(A) = { value = value }
+           |    fun (s : String) box(String, s)
+           |}
+           |""".stripMargin,
+        Seq("def not allowed here", "def not allowed here")
+    )
+
+    test(
+        "rewrite a block containing a function",
+        "{ fun () 0 }",
+        "fun () { 0 }",
+    )
+
+    test(
+        "rewrite a let",
+        "{ type Integer = Int fun () { val x : Integer = 0 x } }",
+        "fun () { type Integer = Int { val x : Integer = 0 x } }"
+    )
+
+    test(
+        "rewrite a let and substitute into arguments",
+        "{ type Text = String fun (text : Text) text }",
+        "fun (text : String) { type Text = String text }"
+    )
+
+    test(
+        "rewrite and substitute multiple lets",
+        """|{
+           |    type File = Writer
+           |    type Text = String
+           |    fun (file : File, text : Text) file.write(text)
+           |}
+           |""".stripMargin,
+        """|fun (file : Writer, text : String) {
+           |    type File = Writer
+           |    type Text = String
+           |    file.write(text)
+           |}
+           |""".stripMargin
+    )
+
+    test(
+        "rewrite a let with concatenation",
+        """|{
+           |    type File = Reader & Writer
+           |    fun (file : File) {
+           |        val result = file.read()
+           |        val _ = file.write("")
+           |        result
+           |    }
+           |}
+           |""".stripMargin,
+        """|fun (file : Reader & Writer) {
+           |    type File = Reader & Writer
+           |    {
+           |        val result = file.read()
+           |        val _ = file.write("")
+           |        result
+           |    }
+           |}
+           |""".stripMargin
+    )
+
+    test(
+        "rewrite a let with application",
+        "{ type IntOption = Option(Int) fun () { } }",
+        "fun () { type IntOption = Option(Int) { } }"
+    )
+
+    test(
+        "rewrite a let with record and variant types",
+        """|{
+           |    type Data = {
+           |        x : Int,
+           |        y : String,
+           |        z : <<
+           |            A : Int,
+           |            B : String
+           |        >>
+           |    }
+           |    fun () { }
+           |}
+           |""".stripMargin,
+        """|fun () {
+           |    type Data = {
+           |        x : Int,
+           |        y : String,
+           |        z : <<
+           |            A : Int,
+           |            B : String
+           |        >>
+           |    }
+           |    { }
+           |}
+           |""".stripMargin
+    )
+
+    test(
+        "rewrite lets with vector aliases",
+        """|{
+           |    type Empty = Vector()
+           |    type IntVector = Vector(Int)
+           |    fun () { }
+           |}
+           |""".stripMargin,
+        """|fun () {
+           |    type Empty = Vector()
+           |    type IntVector = Vector(Int)
+           |    { }
+           |}
+           |""".stripMargin
+    )
+
+    test(
+        "rewrite lets that depend on other lets",
+        """|{
+           |    type Student = { id : Int, name : String, wam : Option(Int) }
+           |    type StudentTable = Table(Student)
+           |    type Db = Database({ student : StudentTable })
+           |    fun (db : Db) db.all()
+           |}
+           |""".stripMargin,
+        """|fun (
+           |    db : Database({
+           |        student : Table({
+           |            id : Int,
+           |            name : String,
+           |            wam : Option(Int)
+           |        })
+           |    })
+           |) {
+           |    type Student = { id : Int, name : String, wam : Option(Int) }
+           |    type StudentTable = Table(Student)
+           |    type Db = Database({ student : StudentTable })
+           |    db.all()
+           |}
+           |""".stripMargin
+    )
+
+    test(
+        "reject unsupported expressions",
+        "{ type Box = fun (A : Type) { value : A } fun () { } }",
+        Seq("not allowed here")
+    )
+
+}

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/TypeAliasTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/TypeAliasTests.scala
@@ -6,37 +6,37 @@ class TypeAliasTests extends SemanticTests {
 
     test(
         "non-type name used as argument type",
-        "{ val x = 1 fun (y : x) y }",
-        """|1:22:error: expected Type, got x of type Int
-           |{ val x = 1 fun (y : x) y }
-           |                     ^
+        "{ val x = 1 val f = fun (y : x) y { } }",
+        """|1:30:error: expected Type, got x of type Int
+           |{ val x = 1 val f = fun (y : x) y { } }
+           |                             ^
            |"""
     )
 
     test(
         "non-type name used as argument type in function type",
-        "{ val x = 1 fun (y : (x) Int) y }",
-        """|1:23:error: expected Type, got x of type Int
-           |{ val x = 1 fun (y : (x) Int) y }
-           |                      ^
+        "{ val x = 1 val f = fun (y : (x) Int) y { } }",
+        """|1:31:error: expected Type, got x of type Int
+           |{ val x = 1 val f = fun (y : (x) Int) y { } }
+           |                              ^
            |"""
     )
 
     test(
         "non-type name used as return type in function type",
-        "{ val x = 1 fun (y : (Int) x) y }",
-        """|1:28:error: expected Type, got x of type Int
-           |{ val x = 1 fun (y : (Int) x) y }
-           |                           ^
+        "{ val x = 1 val f = fun (y : (Int) x) y { } }",
+        """|1:36:error: expected Type, got x of type Int
+           |{ val x = 1 val f = fun (y : (Int) x) y { } }
+           |                                   ^
            |"""
     )
 
     test(
         "non-type name used as field type",
-        "{ val x = 1 fun (y : {a : x}) 1 }",
-        """|1:27:error: expected Type, got x of type Int
-           |{ val x = 1 fun (y : {a : x}) 1 }
-           |                          ^
+        "{ val x = 1 val f = fun (y : {a : x}) 1 { } }",
+        """|1:35:error: expected Type, got x of type Int
+           |{ val x = 1 val f = fun (y : {a : x}) 1 { } }
+           |                                  ^
            |"""
     )
 
@@ -54,7 +54,7 @@ class TypeAliasTests extends SemanticTests {
 
     test(
         "alias of record type",
-        "{ type Foo = { x : Int, y : String } fun (f : Foo) f.x }",
+        "{ type Foo = { x : Int, y : String } val f = fun (f : Foo) f.x { } }",
         ""
     )
 
@@ -63,17 +63,18 @@ class TypeAliasTests extends SemanticTests {
         """{
         |   type Foo = { x : Int, y : String }
         |   type Bar = { x : Int }
-        |   fun (f : Foo, b : Bar) f & b
+        |   val f = fun (f : Foo, b : Bar) f & b
+        |   { }
         |}""",
-        """|4:27:error: record concatenation has overlapping field(s) x
-           |   fun (f : Foo, b : Bar) f & b
-           |                          ^
+        """|4:35:error: record concatenation has overlapping field(s) x
+           |   val f = fun (f : Foo, b : Bar) f & b
+           |                                  ^
            |"""
     )
 
     test(
         "alias of function type",
-        "{ type Foo = (Int) String fun (f : Foo) f(0) }",
+        "{ type Foo = (Int) String val f = fun (f : Foo) f(0) { } }",
         ""
     )
 


### PR DESCRIPTION
This PR allows programs to include type definitions outside the main function. This allows programmers to define type aliases that can be used in the types of arguments of the main function.

For example:

```
fun (
  db: Database({
    table1: Table({
      id : Int,
      a : String,
      b : Option(String)
    }),
    table2 : Table({
      id : Int,
      c : Int
    })
  })
) …
```

…can be expressed as:

```
{
  type Table1 = {
    id : Int,
    a : String,
    b : Option(String)
  }
  type Table2 = {
    id : Int,
    c : Int
  }
  type Db = Database({ table1 : Table1, table2 : Table2 })
  fun (db : Db) …
}
```

The type definitions `Table1`, `Table2`, and `Db` can be used in the rest of the program too.

If a program consists of a block whose return value is a function expression, that function expression is treated as the main function. Any preceding lets may be used in the argument types of the function and elsewhere in the program.

As the top-level lets must be evaluated at compile-time, they cannot be arbitrary expressions. Only the following are allowed:

- identifiers,
- record and variant type literals,
- type concatenation expressions,
- function application.

Defs and block expressions are not allowed.

Programs of this form are rewritten from:

```
{
  <lets>
  fun (<args>) <exp>
}
```

…to:

```
fun (<args_rewritten>) {
  <lets>
  <exp>
}
```

…where `args_rewritten` is `args` with all occurrences of type names declared in `lets` replaced with their respective RHS.

This transformation takes place between desugaring and semantic analysis.