### PR TITLE
Fix bound checking when a type variable is involved

### DIFF
--- a/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
+++ b/commons/src/main/scala/org/bitbucket/inkytonik/cooma/SemanticAnalyser.scala
@@ -1148,6 +1148,10 @@ class SemanticAnalyser(
                 case _                  => None
             }
         unaliased.flatMap {
+            // type variables
+            case (Idn(IdnUse(ti)), Idn(IdnUse(ui))) =>
+                if (ti == ui) Some(Idn(IdnUse(ti)))
+                else None
             // unit
             case (UniT(), UniT()) =>
                 Some(Idn(IdnUse("Unit")))
@@ -1186,6 +1190,10 @@ class SemanticAnalyser(
                 case _                  => None
             }
         unaliased.flatMap {
+            // type variables
+            case (Idn(IdnUse(ti)), Idn(IdnUse(ui))) =>
+                if (ti == ui) Some(Idn(IdnUse(ti)))
+                else None
             // unit
             case (UniT(), UniT()) =>
                 Some(Idn(IdnUse("Unit")))

--- a/prelude/prelude.cooma.dynamic
+++ b/prelude/prelude.cooma.dynamic
@@ -1,4 +1,6 @@
-%letc $k1 Boolean =
+%letv _ =
+  %prim ArgumentCheck 0
+%in %letc $k1 Boolean =
   %letc $k2 false =
     %letc $k3 true =
       %letf

--- a/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/MatchTests.scala
+++ b/src/test/scala/org/bitbucket/inkytonik/cooma/test/semantic/MatchTests.scala
@@ -143,4 +143,18 @@ class MatchTests extends SemanticTests {
         ""
     )
 
+    test(
+        "cases evaluating to a type parameter",
+        """|{
+           |  def ite(t: Type, b: Boolean, l: t, r: t) t =
+           |    b match {
+           |      case True(_) => l
+           |      case False(_) => r
+           |    }
+           |  { }
+           |}
+           |""".stripMargin,
+        ""
+    )
+
 }


### PR DESCRIPTION
I noticed that the prelude failed to compile with the new bound-checking changes. In particular, the semantic analyser complained that the cases in:

```
def ite(t: Type, b: Boolean, l: t, r: t) t =
  b match {
    case True(_) => l
    case False(_) => r
  }
```

…were not of a common type.

The reason is that the bound-checker does not account for type variables. I have fixed this in this PR and added a test case.
